### PR TITLE
[GNTF-9] eslint 에러 해결

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": ["airbnb", "airbnb-typescript"],
   "parserOptions": {
-    "project": ["**/tsconfig.json"],
+    "project": ["**/tsconfig.json"]
   },
   "rules": {
     "react/react-in-jsx-scope": "off",
@@ -15,20 +15,22 @@
         "js": "never",
         "jsx": "never",
         "ts": "never",
-        "tsx": "never",
-      },
+        "tsx": "never"
+      }
     ],
     "no-console": "off",
     "jsx-a11y/label-has-associated-control": "off",
     "react-hooks/exhaustive-deps": "off",
     "react/function-component-definition": [2, { "namedComponents": "arrow-function" }],
+    "linebreak-style": ["error", "windows"],
+    "comma-dangling": "always-multiline"
   },
   "settings": {
     "import/resolver": {
       "typescript": {
         "alwaysTryTypes": true,
-        "project": "./tsconfig.json",
-      },
-    },
-  },
+        "project": "./tsconfig.json"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## 💻 작업 내용

- eslint Missing trailing comma, Expected linebreaks to be 'LF' but found 'CRLF'.eslintlinebreak-style 에러 해결
- 후행 콤마 제거


## 🖼️ 스크린샷

![image](이미지url)


## 🚨 관련 이슈 및 참고 사항

-
