### PR TITLE
[GNTF-11] 로그인 데모 페이지 완성

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,0 +1,55 @@
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+import { AxiosError } from 'axios';
+import axios from '../../lib/axios';
+
+const LoginForm = () => {
+  const [inputs, setInputs] = useState({
+    email: '',
+    password: '',
+  });
+
+  const { email, password } = inputs;
+
+  const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value, name } = e.target;
+    setInputs({
+      ...inputs,
+      [name]: value,
+    });
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      const response = await axios.post('/auth/login', { email, password });
+      const { accessToken, refreshToken } = response.data;
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        console.error('에러 발생:', error.message);
+      } else {
+        console.error('에러 발생:', error);
+      }
+    }
+  };
+  return (
+    <div>
+      <form onSubmit={onSubmit}>
+        <div>
+          <label htmlFor="email">아이디</label>
+          <input name="email" type="email" id="email" onChange={onChangeInput} value={email} />
+        </div>
+
+        <div>
+          <label htmlFor="password">비밀번호</label>
+          <input name="password" type="password" id="password" onChange={onChangeInput} value={password} />
+        </div>
+        <button type="submit">로그인하기</button>
+      </form>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import LoginForm from '../components/login/LoginForm';
 
-const LoginPage = () => <div>로그인 페이지!</div>;
+const LoginPage = () => (
+  <div>
+    로그인을 진행해주세요
+    <LoginForm />
+  </div>
+);
 
 export default LoginPage;


### PR DESCRIPTION
## 💻 작업 내용

- 로그인 데모 페이지를 만들었습니다(에러 메시지 표시X)
- 로그인에 성공했을경우 엑세스, 토큰과 리프레쉬 토큰을 로컬 스토리지에 저장합니다
![스크린샷 2024-05-21 111925](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/e8403d84-df1c-45b7-bf03-00b3d237cf44)
## 🖼️ 스크린샷

![스크린샷 2024-05-21 111917](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/28d898f3-f8e0-4589-8109-46dcb1ba4967)


## 🚨 관련 이슈 및 참고 사항

- 회원가입 페이지와 마찬가지로 아직 에러메시지 표시기능이 없어 네트워크탭을 통해 로그인이 잘 이루어졌는지 확인하시면 됩니다

- 리프레쉬 토큰을 활용하는 기능은 추후에 추가 예정입니다



