### PR TITLE
[GNTF-24] 자주 사용할 width 단위 지정

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,11 @@ module.exports = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      width: {
+        'pc': '1200px',
+        'tab': '744px',
+        'mob': '375px',
+      },
       colors: {
         black: '#171717',
         'nomad-black': '#333236',


### PR DESCRIPTION
## 💻 작업 내용

- 멘토님의 피드백을 듣고 앞으로 자주 사용될 것 같은 width 단위를 tailwind.config 파일에 지정했습니다.
- pc: 1200px
- tab: 744px
- mob: 375px

## 🖼️ 스크린샷


## 🚨 관련 이슈 및 참고 사항

- 해당 단위는 피그마를 참고했습니다.
