### PR TITLE
[GNTF-27] 회원가입 폼 유효성 검사 기능 구현 

### DIFF
--- a/src/api/handleSignup.ts
+++ b/src/api/handleSignup.ts
@@ -1,0 +1,36 @@
+import axiosInstance from '@/lib/axiosInstance';
+
+export interface HandleSignupType {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+class SignupError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super('Signup Error');
+    this.status = status;
+    this.name = 'SignupError';
+  }
+}
+
+const handleSignup = async ({
+  email,
+  nickname,
+  password,
+}: HandleSignupType): Promise<any> => {
+  const response = await axiosInstance.post('/users', {
+    email,
+    nickname,
+    password,
+  });
+
+  if (response.status !== 201) {
+    throw new SignupError(response.status);
+  }
+  return response;
+};
+
+export default handleSignup;

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -17,10 +17,12 @@ const LoginForm = () => {
     passwordErrorMessage: null,
     unexpectedErrorMessage: null,
   });
+
   const [inputs, setInputs] = useState({
     email: '',
     password: '',
   });
+
   const { mutate } = useMutation({
     mutationFn: handleLogin,
     onSuccess: (data) => {

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -1,19 +1,124 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
 
-import { AxiosError } from 'axios';
-import axios from '../../lib/axiosInstance';
+import { useMutation } from '@tanstack/react-query';
+import handleSignup from '@/api/handleSignup';
 
+import { SignupErrorType } from '@/types/signupPage';
+import { AxiosError } from 'axios';
 import AuthButton from '../common/AuthButton';
 import SignupInputBox from './SignupInputBox';
 
 const SignupForm = () => {
+  // 이메일 정규식
+  const emailRegex = /[a-z0-9]+@[a-z]+\.[a-z]{2,3}/;
+
+  // 비밀번호 최소길이
+  const PASSWORD_MIN_LENGTH = 8;
+
+  const [signupErrorMessage, setSignupErrorMessage] = useState<SignupErrorType>(
+    {
+      emailErrorMessage: null,
+      nicknameErrorMessage: null,
+      passwordErrorMessage: null,
+      passwordConfirmErrorMessage: null,
+      unexpectedErrorMessage: null,
+    },
+  );
+
   const [inputs, setInputs] = useState({
     email: '',
     nickname: '',
     password: '',
+    passwordConfirm: '',
   });
 
-  const { email, nickname, password } = inputs;
+  const { mutate } = useMutation({
+    mutationFn: handleSignup,
+    onSuccess: () => {
+      setSignupErrorMessage({
+        emailErrorMessage: null,
+        nicknameErrorMessage: null,
+        passwordErrorMessage: null,
+        passwordConfirmErrorMessage: null,
+        unexpectedErrorMessage: null,
+      });
+      alert('회원가입이 완료 되었습니다');
+    },
+    onError: (error: AxiosError) => {
+      if (error.response) {
+        const { email, nickname, password } = inputs;
+
+        if (error.response.status === 409) {
+          setSignupErrorMessage({
+            emailErrorMessage: '중복된 이메일입니다.',
+            nicknameErrorMessage: null,
+            passwordErrorMessage: null,
+            passwordConfirmErrorMessage: null,
+            unexpectedErrorMessage: null,
+          });
+        } else if (error.request.status === 400) {
+          // 이메일 확인
+          if (email.length === 0) {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              emailErrorMessage: '이메일을 입력해주세요.',
+            }));
+          } else if (!emailRegex.test(email)) {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              emailErrorMessage: '이메일 형식으로 작성해주세요.',
+            }));
+          } else {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              emailErrorMessage: null,
+            }));
+          }
+
+          // 닉네임 확인
+          if (nickname.length === 0) {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: '닉네임을 입력해주세요.',
+            }));
+          } else if (nickname.length > 10) {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: '닉네임은 10자 이하로 작성해주세요.',
+            }));
+          } else {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: null,
+            }));
+          }
+
+          // 비밀번호 확인
+          if (password.length === 0) {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              passwordErrorMessage: '비밀번호를 입력해주세요.',
+            }));
+          } else if (
+            password.length > 0 &&
+            password.length < PASSWORD_MIN_LENGTH
+          ) {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              passwordErrorMessage: '8자 이상 작성해 주세요.',
+            }));
+          } else {
+            setSignupErrorMessage((prev) => ({
+              ...prev,
+              passwordErrorMessage: null,
+            }));
+          }
+        }
+      }
+    },
+  });
+
+  const { email, nickname, password, passwordConfirm } = inputs;
 
   const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     const { value, name } = e.target;
@@ -25,39 +130,80 @@ const SignupForm = () => {
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    try {
-      await axios.post('/users', { email, nickname, password });
-    } catch (error) {
-      if (error instanceof AxiosError) {
-        console.error('에러 발생:', error.message);
-      } else {
-        console.error('에러 발생:', error);
+
+    if (password !== passwordConfirm) {
+      if (password.length > 0 && password.length < PASSWORD_MIN_LENGTH) {
+        setSignupErrorMessage((prev) => ({
+          ...prev,
+          passwordErrorMessage: '8자 이상 작성해 주세요.',
+        }));
       }
+      if (passwordConfirm.length === 0) {
+        setSignupErrorMessage((prev) => ({
+          ...prev,
+          passwordConfirmErrorMessage: '비밀번호 확인값을 입력해주세요.',
+        }));
+      } else {
+        setSignupErrorMessage((prev) => ({
+          ...prev,
+          passwordConfirmErrorMessage: '비밀번호가 일치하지 않습니다.',
+        }));
+      }
+
+      return;
     }
+
+    // 비밀번호가 일치하면 에러 메시지 초기화
+    setSignupErrorMessage((prev) => ({
+      ...prev,
+      passwordConfirmErrorMessage: null,
+    }));
+
+    mutate({ email, nickname, password });
   };
+
   return (
     <div>
       <form
         onSubmit={onSubmit}
         className="flex flex-col gap-7 w-[40rem] mx-auto"
+        noValidate
       >
         <SignupInputBox
           inputName="email"
           onChangeInput={onChangeInput}
           value={email}
           labelName="이메일"
+          inputType="email"
+          signupErrorMessage={signupErrorMessage}
+          setSignupErrorMessage={setSignupErrorMessage}
         />
         <SignupInputBox
           inputName="nickname"
           onChangeInput={onChangeInput}
           value={nickname}
           labelName="닉네임"
+          inputType="text"
+          signupErrorMessage={signupErrorMessage}
+          setSignupErrorMessage={setSignupErrorMessage}
         />
         <SignupInputBox
           inputName="password"
           onChangeInput={onChangeInput}
           value={password}
           labelName="비밀번호"
+          inputType="password"
+          signupErrorMessage={signupErrorMessage}
+          setSignupErrorMessage={setSignupErrorMessage}
+        />
+        <SignupInputBox
+          inputName="passwordConfirm"
+          onChangeInput={onChangeInput}
+          value={passwordConfirm}
+          labelName="비밀번호 확인"
+          inputType="password"
+          signupErrorMessage={signupErrorMessage}
+          setSignupErrorMessage={setSignupErrorMessage}
         />
         <AuthButton>회원가입</AuthButton>
       </form>

--- a/src/components/signup/SignupInputBox.tsx
+++ b/src/components/signup/SignupInputBox.tsx
@@ -1,4 +1,6 @@
 import { ChangeEvent, useState } from 'react';
+
+import { SignupErrorType } from '@/types/signupPage';
 import AuthLabel from '../common/AuthLabel';
 
 interface SignupInputBoxProps {
@@ -6,6 +8,9 @@ interface SignupInputBoxProps {
   onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void;
   value: string;
   labelName: string;
+  inputType: string;
+  signupErrorMessage: SignupErrorType | null;
+  setSignupErrorMessage: React.Dispatch<React.SetStateAction<SignupErrorType>>;
 }
 
 const SignupInputBox = ({
@@ -13,47 +18,107 @@ const SignupInputBox = ({
   onChangeInput,
   value,
   labelName,
+  inputType,
+  signupErrorMessage,
+  setSignupErrorMessage,
 }: SignupInputBoxProps) => {
   const [isShowInputValue, setIsShowInputValue] = useState(false);
-  const [inputType, setInputType] = useState(inputName);
+  const [changeInputType, setChangeInputType] = useState(inputType);
 
+  const onClickInput = () => {
+    if (inputName === 'email') {
+      setSignupErrorMessage((prev) => ({
+        ...prev,
+        emailErrorMessage: null,
+      }));
+    } else if (inputName === 'nickname') {
+      setSignupErrorMessage((prev) => ({
+        ...prev,
+        nicknameErrorMessage: null,
+      }));
+    } else if (inputName === 'password') {
+      setSignupErrorMessage((prev) => ({
+        ...prev,
+        passwordErrorMessage: null,
+      }));
+    } else if (inputName === 'passwordConfirm') {
+      setSignupErrorMessage((prev) => ({
+        ...prev,
+        passwordConfirmErrorMessage: null,
+      }));
+    }
+  };
   const onClickEyeIcon = () => {
-    if (inputType === 'password') {
-      setInputType('text');
+    if (labelName.includes('비밀번호')) {
+      setChangeInputType('text');
     } else if (inputType === 'text') {
-      setInputType('password');
+      setChangeInputType('password');
     }
     setIsShowInputValue((prev) => !prev);
   };
-
+  let borderColorClass = '';
+  if (inputName === 'email' && signupErrorMessage?.emailErrorMessage) {
+    borderColorClass = 'border-red-40';
+  } else if (inputName === 'nickname' && signupErrorMessage?.nicknameErrorMessage) {
+    borderColorClass = 'border-red-40';
+  } else if (inputName === 'password' && signupErrorMessage?.passwordErrorMessage) {
+    borderColorClass = 'border-red-40';
+  } else if (inputName === 'passwordConfirm' && signupErrorMessage?.passwordConfirmErrorMessage
+  ) {
+    borderColorClass = 'border-red-40';
+  }
   return (
     <div className="flex flex-col gap-2 relative">
       <AuthLabel labelName={labelName} />
-      <input
-        name={inputName}
-        type={inputType}
-        id={inputName}
-        onChange={onChangeInput}
-        value={value}
-        className="border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none"
-      />
-      {labelName === '비밀번호' ? (
-        <button
-          onClick={onClickEyeIcon}
-          type="button"
-          className="text-[0px] absolute bottom-[16px] right-[20px]"
-        >
-          <img
-            src={
-              isShowInputValue === true
-                ? '/assets/visibility_on_btn.svg'
-                : '/assets/visibility_off_btn.svg'
-            }
-            alt="arrow_image"
-            className="w-[24px] h-[24px]"
-          />
-        </button>
-      ) : null}
+      <div className="relative">
+        <input
+          name={inputName}
+          type={changeInputType}
+          id={inputName}
+          onChange={onChangeInput}
+          value={value}
+          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass}`}
+          onClick={onClickInput}
+        />
+        {labelName.includes('비밀번호') === true ? (
+          <button
+            onClick={onClickEyeIcon}
+            type="button"
+            className="text-[0px] absolute bottom-[16px] right-[20px]"
+          >
+            <img
+              src={
+                isShowInputValue === true
+                  ? '/assets/visibility_on_btn.svg'
+                  : '/assets/visibility_off_btn.svg'
+              }
+              alt="arrow_image"
+              className="w-[24px] h-[24px]"
+            />
+          </button>
+        ) : null}
+      </div>
+      {inputName === 'email' && signupErrorMessage?.emailErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">
+          {signupErrorMessage.emailErrorMessage}
+        </div>
+      )}
+      {inputName === 'nickname' && signupErrorMessage?.nicknameErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">
+          {signupErrorMessage.nicknameErrorMessage}
+        </div>
+      )}
+
+      {inputName === 'password' && signupErrorMessage?.passwordErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">
+          {signupErrorMessage.passwordErrorMessage}
+        </div>
+      )}
+      {inputName === 'passwordConfirm' && signupErrorMessage?.passwordConfirmErrorMessage && (
+          <div className="text-red-40 text-xs ml-1">
+            {signupErrorMessage.passwordConfirmErrorMessage}
+          </div>
+        )}
     </div>
   );
 };

--- a/src/types/signupPage.ts
+++ b/src/types/signupPage.ts
@@ -1,0 +1,7 @@
+export interface SignupErrorType {
+  emailErrorMessage: string | null;
+  nicknameErrorMessage: string | null;
+  passwordErrorMessage: string | null;
+  passwordConfirmErrorMessage: string | null;
+  unexpectedErrorMessage: string | null;
+}


### PR DESCRIPTION
## 💻 작업 내용

- 회원가입폼에서 유효성 검사를 실행합니다(리액트훅폼 사용X)
- 회원가입폼에서 사용하는 비동기처리를 tanstackquery로 마이그레이션 했습니다
 
> 에러메시지 상세(인풋창 클릭시 에러메시지가 없어집니다)

- 이메일이 없을경우: "이메일을 입력해주세요"
- 이메일 정규식을 통과하지 못할경우 : '이메일 형식으로 작성해주세요.'
</br>

- 닉네임이 없을경우: "닉네임을 입력해주세요."
- 닉네임의 길이가 10자를 초과할 경우 : '닉네임은 10자 이하로 작성해주세요.'
</br>

- 비밀번호가 없을 경우 : '비밀번호를 입력해주세요.'
- 비밀번호의 길이가 8보다 작을경우 :  '8자 이상 작성해 주세요.'
</br>

- 비밀번호값과 비밀번호 확인값이 모두 공백이 아니고 둘중에 하나의 값이라도 채워져있을때 두 값이 다를 경우:  비밀번호가 일치하지 않습니다.
</br>

- 이메일, 닉네임 ,비밀번호, 비밀번호확인값  유효성을 모두 통과했지만 중복되는 이메일인 경우 : '중복된 이메일입니다.'
</br>

- 위의 조건을 모두 만족할경우 : 에러메세지가 모두 사라지고 회원가입에 성공합니다(alert 창으로 회원가입이 완료되었다는 알림 표시)

## 🖼️ 스크린샷

![Global Nomad - Chrome 2024-05-25 19-20-54](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/3b53382f-809a-4573-a774-484e6838ab63)






## 🚨 관련 이슈 및 참고 사항

- 버튼 비활성화 기능 추가 예정
- alert 관련 기능 회의 해보면 좋을꺼 같습니다