### PR TITLE
[GNTF-35] 모든 체험 Card 리스트 api 연결 및 Pagination 컴포넌트 재수정

### DIFF
--- a/src/api/getCurrentPageActivity.ts
+++ b/src/api/getCurrentPageActivity.ts
@@ -1,0 +1,21 @@
+import axiosInstance from '@/lib/axiosInstance';
+import { ActivityResponse } from '@/types/mainPage';
+
+const defaultActivityResponse: ActivityResponse = {
+  activities: [],
+  totalCount: 0,
+};
+
+const getCurrentPageActivity = async (pageNum: number, size: number): Promise<ActivityResponse> => {
+  try {
+    const res = await axiosInstance.get<ActivityResponse>(
+      `/activities?method=offset&page=${pageNum + 1}&size=${size}`
+    );
+    return res.data;
+  } catch (e) {
+    console.error('Error: ', e);
+    return defaultActivityResponse;
+  }
+};
+
+export default getCurrentPageActivity;

--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -1,3 +1,5 @@
+import priceToWon from '@/utils/priceToWon';
+
 export interface ActivityCardProps {
   cardData: {
     id: number;
@@ -46,7 +48,7 @@ const ActivityCard = ({ cardData }: ActivityCardProps) => {
         </div>
         <div className="text-2xl font-bold">{title}</div>
         <div className="flex items-center gap-1 text-[28px] font-bold">
-          {`₩ ${price}`}
+          {priceToWon(price)}
           <span className="text-xl text-gray-80">/인</span>
         </div>
       </div>

--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -37,7 +37,7 @@ const ActivityCard = ({ cardData }: ActivityCardProps) => {
 
   return (
     <div id={String(id)} className="flex flex-col gap-4">
-      <div className="w-72 h-72 bg-cover bg-center rounded-3xl" style={{ backgroundImage: `url('${bannerImageUrl}')` }} />
+      <div className="w-72 h-72 bg-cover bg-center rounded-3xl" style={{ backgroundImage: `url(${bannerImageUrl})` }} />
       <div className="flex flex-col gap-[10px] w-[282px] text-black">
         <div className="flex gap-1">
           <img src="/assets/bold_star.svg" alt="little-star" />

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -1,15 +1,13 @@
 import Pagination from '@/components/mainpage/Pagination';
 import ActivityCard from '@/components/mainpage/ActivityCard';
-import { ActivityResponse } from '@/lib/utils/activity_mock_data';
+import { ActivityInfo, ActivityResponse } from '@/lib/utils/activity_mock_data';
 import { useEffect, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
 
 const OFFSET_LIMIT = 8;
 
-// 우선 임의로 any 타입 지정. 후에 수정이 필요함.
-
 const ActivityCardList = () => {
-  const [currenData, setCurrentData] = useState<any[]>([]);
+  const [currenData, setCurrentData] = useState<ActivityInfo[]>([]);
   const [count, setCount] = useState(1);
 
   // 처음으로 렌더링 시 1페이지 데이터를 불러오는 함수.

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -12,15 +12,7 @@ const ActivityCardList = () => {
   const [currenData, setCurrentData] = useState<any[]>([]);
   const [count, setCount] = useState(1);
 
-  // const pageDataList: any[] = [];
-  // for (let i = 0; i < totalCount; i += 8) {
-  //   pageDataList.push(activities.slice(i, i + 8));
-  // }
-
-  // const handlePageData = (pageNum: number) => {
-  //   setCurrentData(pageDataList[pageNum]);
-  // };
-
+  // 처음으로 렌더링 시 1페이지 데이터를 불러오는 함수.
   async function getActivityData() {
     const res = await axiosInstance.get<ActivityResponse>(
       `/activities?method=offset&page=1&size=${OFFSET_LIMIT}`
@@ -28,7 +20,7 @@ const ActivityCardList = () => {
     return res.data;
   }
 
-  // api 함수 연결했을 때 예시
+  // 페이지를 넘길 때마다 해당 페이지의 데이터를 불러오는 함수.
   const handlePageData = async (pageNum: number, size: number) => {
     try {
       const res = await axiosInstance.get<ActivityResponse>(
@@ -41,7 +33,6 @@ const ActivityCardList = () => {
     }
   };
 
-  // api 연결 이후에 맞춰서 다시 변경 예정
   useEffect(() => {
     const fetchPageData = async () => {
       const data = await getActivityData();

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -1,37 +1,52 @@
 import Pagination from '@/components/mainpage/Pagination';
 import ActivityCard from '@/components/mainpage/ActivityCard';
-import { EXAMPLE_MORE_ACTIVITIES } from '@/lib/utils/activity_mock_data';
+import { ActivityResponse } from '@/lib/utils/activity_mock_data';
 import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
 
 const OFFSET_LIMIT = 8;
 
 // 우선 임의로 any 타입 지정. 후에 수정이 필요함.
 
 const ActivityCardList = () => {
-  const [currenData, setCurrentData] = useState<any[]>();
-  const { activities, totalCount } = EXAMPLE_MORE_ACTIVITIES;
+  const [currenData, setCurrentData] = useState<any[]>([]);
+  const [count, setCount] = useState(1);
 
-  const pageDataList: any[] = [];
-  for (let i = 0; i < totalCount; i += 8) {
-    pageDataList.push(activities.slice(i, i + 8));
+  // const pageDataList: any[] = [];
+  // for (let i = 0; i < totalCount; i += 8) {
+  //   pageDataList.push(activities.slice(i, i + 8));
+  // }
+
+  // const handlePageData = (pageNum: number) => {
+  //   setCurrentData(pageDataList[pageNum]);
+  // };
+
+  async function getActivityData() {
+    const res = await axiosInstance.get<ActivityResponse>(
+      `/activities?method=offset&page=1&size=${OFFSET_LIMIT}`
+    );
+    return res.data;
   }
 
-  const handlePageData = (pageNum: number) => {
-    setCurrentData(pageDataList[pageNum]);
-  };
-
   // api 함수 연결했을 때 예시
-  // const handlePageData = (pageNum: number, size: number) => {
-  //   const { activities } = axios.get(
-  //   `/activities?method=offset&page=${pageNum}&size=${OFFSET_LIMIT}`
-  // );
-  //   setApplyData(res);
-  // };
+  const handlePageData = async (pageNum: number, size: number) => {
+    try {
+      const res = await axiosInstance.get<ActivityResponse>(
+        `/activities?method=offset&page=${pageNum + 1}&size=${size}`
+      );
+      const { activities } = res.data;
+      setCurrentData(activities);
+    } catch (e) {
+      console.error('Error: ', e);
+    }
+  };
 
   // api 연결 이후에 맞춰서 다시 변경 예정
   useEffect(() => {
     const fetchPageData = async () => {
-      setCurrentData(pageDataList[0]);
+      const data = await getActivityData();
+      setCurrentData(data.activities);
+      setCount(data.totalCount);
     };
     fetchPageData();
   }, []);
@@ -43,7 +58,7 @@ const ActivityCardList = () => {
           <ActivityCard cardData={activity} />
         ))}
       </div>
-      <Pagination totalCount={totalCount} limit={OFFSET_LIMIT} setActivityList={handlePageData} />
+      <Pagination totalCount={count} limit={OFFSET_LIMIT} setActivityList={handlePageData} />
     </>
   );
 };

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -11,7 +11,7 @@ const ActivityCardList = () => {
   const [count, setCount] = useState(1);
 
   // 처음으로 렌더링 시 1페이지 데이터를 불러오는 함수.
-  async function getActivityData() {
+  async function getFirstPageActivity() {
     const res = await axiosInstance.get<ActivityResponse>(
       `/activities?method=offset&page=1&size=${OFFSET_LIMIT}`
     );
@@ -19,7 +19,7 @@ const ActivityCardList = () => {
   }
 
   // 페이지를 넘길 때마다 해당 페이지의 데이터를 불러오는 함수.
-  const handlePageData = async (pageNum: number, size: number) => {
+  const getPageData = async (pageNum: number, size: number) => {
     try {
       const res = await axiosInstance.get<ActivityResponse>(
         `/activities?method=offset&page=${pageNum + 1}&size=${size}`
@@ -33,7 +33,7 @@ const ActivityCardList = () => {
 
   useEffect(() => {
     const fetchPageData = async () => {
-      const data = await getActivityData();
+      const data = await getFirstPageActivity();
       setCurrentData(data.activities);
       setCount(data.totalCount);
     };
@@ -47,7 +47,7 @@ const ActivityCardList = () => {
           <ActivityCard cardData={activity} />
         ))}
       </div>
-      <Pagination totalCount={count} limit={OFFSET_LIMIT} setActivityList={handlePageData} />
+      <Pagination totalCount={count} limit={OFFSET_LIMIT} setActivityList={getPageData} />
     </>
   );
 };

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -3,6 +3,7 @@ import ActivityCard from '@/components/mainpage/ActivityCard';
 import { useEffect, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
 import { ActivityInfo, ActivityResponse } from '@/types/mainPage';
+import getCurrentPageActivity from '@/api/getCurrentPageActivity';
 
 const OFFSET_LIMIT = 8;
 
@@ -21,10 +22,7 @@ const ActivityCardList = () => {
   // 페이지를 넘길 때마다 해당 페이지의 데이터를 불러오는 함수.
   const getPageData = async (pageNum: number, size: number) => {
     try {
-      const res = await axiosInstance.get<ActivityResponse>(
-        `/activities?method=offset&page=${pageNum + 1}&size=${size}`
-      );
-      const { activities } = res.data;
+      const { activities } = await getCurrentPageActivity(pageNum, size);
       setCurrentData(activities);
     } catch (e) {
       console.error('Error: ', e);

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -1,8 +1,8 @@
 import Pagination from '@/components/mainpage/Pagination';
 import ActivityCard from '@/components/mainpage/ActivityCard';
-import { ActivityInfo, ActivityResponse } from '@/lib/utils/activity_mock_data';
 import { useEffect, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
+import { ActivityInfo, ActivityResponse } from '@/types/mainPage';
 
 const OFFSET_LIMIT = 8;
 

--- a/src/components/mainpage/Pagination.tsx
+++ b/src/components/mainpage/Pagination.tsx
@@ -3,12 +3,13 @@ import { MouseEvent, useState } from 'react';
 interface PaginationProp {
   totalCount: number;
   limit: number;
-  setActivityList: (pageNum: number) => void;
+  setActivityList: (pageNum: number, size: number) => void;
 }
 
 /**
  * @param {number} totalCount 총 데이터의 개수.
  * @param {number} limit 한 페이지 당 나타낼 데이터의 개수.
+ * @param {StateSetFunction} setActivityList 현재 페이지에서 보여줄 데이터를 설정하는 함수.
  */
 
 const Pagination = ({ totalCount, limit, setActivityList }: PaginationProp) => {
@@ -32,7 +33,7 @@ const Pagination = ({ totalCount, limit, setActivityList }: PaginationProp) => {
   const handlePageBtnClick = (e: MouseEvent<HTMLButtonElement>) => {
     const button = e.target as HTMLButtonElement;
     setCurrentPage(+button.id);
-    setActivityList(+button.id);
+    setActivityList(+button.id, limit);
   };
 
   // 왼쪽 arrow 버튼으로 이동 시 실행할 함수
@@ -40,7 +41,7 @@ const Pagination = ({ totalCount, limit, setActivityList }: PaginationProp) => {
     if (currentPage !== 0 && (currentPage % 5) === 0) setCurrentPageGroup(currentPageGroup - 1);
     if (currentPage === 0) return;
     setCurrentPage(currentPage - 1);
-    setActivityList(currentPage - 1);
+    setActivityList(currentPage - 1, limit);
   };
 
   // 오른쪽 arrow 버튼으로 이동 시 실행할 함수
@@ -50,7 +51,7 @@ const Pagination = ({ totalCount, limit, setActivityList }: PaginationProp) => {
     }
     if (currentPage === (pageNumber.length - 1)) return;
     setCurrentPage(currentPage + 1);
-    setActivityList(currentPage + 1);
+    setActivityList(currentPage + 1, limit);
   };
 
   return (

--- a/src/lib/utils/activity_mock_data.ts
+++ b/src/lib/utils/activity_mock_data.ts
@@ -1,36 +1,3 @@
-export type ActivityResponse = {
-  activities: {
-    id: number;
-    userId: number;
-    title: string;
-    description: string;
-    category: string;
-    price: number;
-    address: string;
-    bannerImageUrl: string;
-    rating: number;
-    reviewCount: number;
-    createdAt: string;
-    updatedAt: string;
-  }[]
-  totalCount: number;
-};
-
-export type ActivityInfo = {
-  id: number;
-  userId: number;
-  title: string;
-  description: string;
-  category: string;
-  price: number;
-  address: string;
-  bannerImageUrl: string;
-  rating: number;
-  reviewCount: number;
-  createdAt: string;
-  updatedAt: string;
-};
-
 export const EXAMPLE_ACTIVITY = {
   activities: [
     {

--- a/src/lib/utils/activity_mock_data.ts
+++ b/src/lib/utils/activity_mock_data.ts
@@ -16,6 +16,21 @@ export type ActivityResponse = {
   totalCount: number;
 };
 
+export type ActivityInfo = {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export const EXAMPLE_ACTIVITY = {
   activities: [
     {

--- a/src/lib/utils/activity_mock_data.ts
+++ b/src/lib/utils/activity_mock_data.ts
@@ -13,6 +13,7 @@ export type ActivityResponse = {
     createdAt: string;
     updatedAt: string;
   }[]
+  totalCount: number;
 };
 
 export const EXAMPLE_ACTIVITY = {

--- a/src/types/mainPage.ts
+++ b/src/types/mainPage.ts
@@ -1,0 +1,32 @@
+export type ActivityResponse = {
+  activities: {
+    id: number;
+    userId: number;
+    title: string;
+    description: string;
+    category: string;
+    price: number;
+    address: string;
+    bannerImageUrl: string;
+    rating: number;
+    reviewCount: number;
+    createdAt: string;
+    updatedAt: string;
+  }[]
+  totalCount: number;
+};
+
+export type ActivityInfo = {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
## 💻 작업 내용

- 기존에 만들었던 mock 데이터 대신에 api 호출로 데이터를 가져와 컴포넌트에 연결했습니다.
- priceToWon 함수 적용했습니다.
- any 타입을 제거하고 타입을 새로 작성 및 적용했습니다.


## 🖼️ 스크린샷

![스크린샷 2024-05-29 154119](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/41c53de8-e5f9-488c-8b31-d2da20cb2298)
![스크린샷 2024-05-29 154136](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/9997b9ea-087e-4f73-adeb-1b592a3122b0)



## 🚨 관련 이슈 및 참고 사항

- 현재 card의 이미지가 안뜨는 이슈가 있습니다. 이후 해결할 예정입니다.
- pagination 컴포넌트에 필요한 prop에 관해서 JSdoc을 작성해 놓았습니다. ActivityCardList.tsx를 참고하셔서 작성해보시고 질문이 있으시면 디엠이나 카톡 등을 통해서 질문해 주세요~!
