### PR TITLE
[GNTF-45] 메인페이지 인기 체험 리스트 api 연결

### DIFF
--- a/src/api/getCurrentPageActivity.ts
+++ b/src/api/getCurrentPageActivity.ts
@@ -6,10 +6,24 @@ const defaultActivityResponse: ActivityResponse = {
   totalCount: 0,
 };
 
-const getCurrentPageActivity = async (pageNum: number, size: number): Promise<ActivityResponse> => {
+const getCurrentPageActivity = async (
+  pageNum: number,
+  size: number,
+  category?: string,
+  keyword?: string
+): Promise<ActivityResponse> => {
+  const urlSearchParams = new URLSearchParams({
+    method: 'offset',
+    page: String(pageNum),
+    size: String(size),
+  });
+
+  if (category) urlSearchParams.append('category', category);
+  if (keyword) urlSearchParams.append('keyword', keyword);
+
   try {
     const res = await axiosInstance.get<ActivityResponse>(
-      `/activities?method=offset&page=${pageNum + 1}&size=${size}`
+      `/activities?${urlSearchParams}`
     );
     return res.data;
   } catch (e) {
@@ -17,5 +31,17 @@ const getCurrentPageActivity = async (pageNum: number, size: number): Promise<Ac
     return defaultActivityResponse;
   }
 };
+
+// export const getActivity = async (pageNum: number, size: number): Promise<ActivityResponse> => {
+//   try {
+//     const res = await axiosInstance.get<ActivityResponse>(
+//       `/activities?method=offset&page=${pageNum + 1}&size=${size}`
+//     );
+//     return res.data;
+//   } catch (e) {
+//     console.error('Error: ', e);
+//     return defaultActivityResponse;
+//   }
+// };
 
 export default getCurrentPageActivity;

--- a/src/api/getCurrentPageActivity.ts
+++ b/src/api/getCurrentPageActivity.ts
@@ -14,7 +14,7 @@ const getCurrentPageActivity = async (
 ): Promise<ActivityResponse> => {
   const urlSearchParams = new URLSearchParams({
     method: 'offset',
-    page: String(pageNum),
+    page: String(pageNum + 1),
     size: String(size),
   });
 

--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -1,4 +1,5 @@
 import priceToWon from '@/utils/priceToWon';
+import { Link } from 'react-router-dom';
 
 export interface ActivityCardProps {
   cardData: {
@@ -36,23 +37,25 @@ const ActivityCard = ({ cardData }: ActivityCardProps) => {
   const { id, title, price, bannerImageUrl, rating, reviewCount } = cardData;
 
   return (
-    <div id={String(id)} className="flex flex-col gap-4">
-      <div className="w-72 h-72 bg-cover bg-center rounded-3xl" style={{ backgroundImage: `url(${bannerImageUrl})` }} />
-      <div className="flex flex-col gap-[10px] w-[282px] text-black">
-        <div className="flex gap-1">
-          <img src="/assets/bold_star.svg" alt="little-star" />
-          <p className="text-sm font-bold">
-            {rating}
-            <span className="text-gray-60">{` (${reviewCount})`}</span>
-          </p>
-        </div>
-        <div className="text-2xl font-bold">{title}</div>
-        <div className="flex items-center gap-1 text-[28px] font-bold">
-          {priceToWon(price)}
-          <span className="text-xl text-gray-80">/인</span>
+    <Link to={`/activity/${id}`}>
+      <div className="flex flex-col gap-4">
+        <div className="w-72 h-72 bg-cover bg-center rounded-3xl" style={{ backgroundImage: `url(${bannerImageUrl})` }} />
+        <div className="flex flex-col gap-[10px] w-[282px] text-black">
+          <div className="flex gap-1">
+            <img src="/assets/bold_star.svg" alt="little-star" />
+            <p className="text-sm font-bold">
+              {rating}
+              <span className="text-gray-60">{` (${reviewCount})`}</span>
+            </p>
+          </div>
+          <div className="text-2xl font-bold">{title}</div>
+          <div className="flex items-center gap-1 text-[28px] font-bold">
+            {priceToWon(price)}
+            <span className="text-xl text-gray-80">/인</span>
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -45,7 +45,7 @@ const ActivityCardList = () => {
           <ActivityCard key={activity.id} cardData={activity} />
         ))}
       </div>
-      <Pagination totalCount={count} limit={OFFSET_LIMIT} setActivityList={getPageData} />
+      <Pagination totalCount={count} offsetLimit={OFFSET_LIMIT} setActivityList={getPageData} />
     </>
   );
 };

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -1,8 +1,7 @@
 import Pagination from '@/components/mainpage/Pagination';
 import ActivityCard from '@/components/mainpage/ActivityCard';
 import { useEffect, useState } from 'react';
-import axiosInstance from '@/lib/axiosInstance';
-import { ActivityInfo, ActivityResponse } from '@/types/mainPage';
+import { ActivityInfo } from '@/types/mainPage';
 import getCurrentPageActivity from '@/api/getCurrentPageActivity';
 
 const OFFSET_LIMIT = 8;
@@ -11,16 +10,8 @@ const ActivityCardList = () => {
   const [currenData, setCurrentData] = useState<ActivityInfo[]>([]);
   const [count, setCount] = useState(1);
 
-  // 처음으로 렌더링 시 1페이지 데이터를 불러오는 함수.
-  async function getFirstPageActivity() {
-    const res = await axiosInstance.get<ActivityResponse>(
-      `/activities?method=offset&page=1&size=${OFFSET_LIMIT}`
-    );
-    return res.data;
-  }
-
   // 페이지를 넘길 때마다 해당 페이지의 데이터를 불러오는 함수.
-  const getPageData = async (pageNum: number, size: number) => {
+  const handlePageData = async (pageNum: number, size: number) => {
     try {
       const { activities } = await getCurrentPageActivity(pageNum, size);
       setCurrentData(activities);
@@ -31,7 +22,7 @@ const ActivityCardList = () => {
 
   useEffect(() => {
     const fetchPageData = async () => {
-      const data = await getFirstPageActivity();
+      const data = await getCurrentPageActivity(1, OFFSET_LIMIT);
       setCurrentData(data.activities);
       setCount(data.totalCount);
     };
@@ -41,11 +32,11 @@ const ActivityCardList = () => {
   return (
     <>
       <div className="grid grid-cols-4 gap-6 mb-[72px]">
-        {currenData?.map((activity) => (
+        {currenData.map((activity) => (
           <ActivityCard key={activity.id} cardData={activity} />
         ))}
       </div>
-      <Pagination totalCount={count} offsetLimit={OFFSET_LIMIT} setActivityList={getPageData} />
+      <Pagination totalCount={count} offsetLimit={OFFSET_LIMIT} setActivityList={handlePageData} />
     </>
   );
 };

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -42,7 +42,7 @@ const ActivityCardList = () => {
     <>
       <div className="grid grid-cols-4 gap-6 mb-[72px]">
         {currenData?.map((activity) => (
-          <ActivityCard cardData={activity} />
+          <ActivityCard key={activity.id} cardData={activity} />
         ))}
       </div>
       <Pagination totalCount={count} limit={OFFSET_LIMIT} setActivityList={getPageData} />

--- a/src/components/mainpage/ActivitySearch.tsx
+++ b/src/components/mainpage/ActivitySearch.tsx
@@ -16,7 +16,7 @@ const ActivitySearch = () => {
           <div className="relative">
             <input
               className="w-[62.5rem] h-14 border border-gray-60 border-solid rounded-md px-4 py-2 placeholder:pl-5 focus:outline-none focus:border-green-40"
-              type="text"
+              type="search"
               onChange={handleChange}
               placeholder="내가 원하는 체험은"
             />
@@ -27,7 +27,7 @@ const ActivitySearch = () => {
             />
           </div>
           <button
-            type="button"
+            type="submit"
             className="bg-nomad-black rounded-md w-[136px] h-14 px-10 py-2 text-white font-bold"
           >
             검색하기

--- a/src/components/mainpage/CategoryFilter.tsx
+++ b/src/components/mainpage/CategoryFilter.tsx
@@ -5,11 +5,18 @@ const CATEGORY_LIST = ['문화 · 예술', '식음료', '스포츠', '투어', '
 
 const CategoryFilter = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [currentCategory, setCurrentCategory] = useState('');
 
-  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleFilterClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setIsOpen(!isOpen);
   };
+
+  const handleCategoryClick = (e: MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    setCurrentCategory(button.value);
+  };
+  console.log(currentCategory);
 
   return (
     <div className="flex justify-between text-green-80">
@@ -19,6 +26,8 @@ const CategoryFilter = () => {
             className="w-[127px] text-lg border border-green-80 rounded-2xl px-5 py-4 hover:bg-green-80 hover:text-white"
             type="button"
             key={category}
+            value={category}
+            onClick={handleCategoryClick}
           >
             {category}
           </button>
@@ -27,7 +36,7 @@ const CategoryFilter = () => {
       <div className="relative flex flex-col">
         <button
           className="flex justify-between items-center w-[127px] text-lg border border-green-80 rounded-2xl px-5 py-4"
-          onClick={handleClick}
+          onClick={handleFilterClick}
           type="button"
         >
           가격

--- a/src/components/mainpage/CategoryFilter.tsx
+++ b/src/components/mainpage/CategoryFilter.tsx
@@ -8,8 +8,7 @@ const CategoryFilter = () => {
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (isOpen) return setIsOpen(false);
-    return setIsOpen(true);
+    setIsOpen(!isOpen);
   };
 
   return (

--- a/src/components/mainpage/Pagination.tsx
+++ b/src/components/mainpage/Pagination.tsx
@@ -2,22 +2,29 @@ import { MouseEvent, useState } from 'react';
 
 interface PaginationProp {
   totalCount: number;
-  limit: number;
+  offsetLimit: number;
+  pageNumberLimit?: number;
   setActivityList: (pageNum: number, size: number) => void;
 }
 
 /**
- * @param {number} totalCount 총 데이터의 개수.
- * @param {number} limit 한 페이지 당 나타낼 데이터의 개수.
- * @param {StateSetFunction} setActivityList 현재 페이지에서 보여줄 데이터를 설정하는 함수.
+ * @param totalCount 총 데이터의 개수.
+ * @param offsetLimit 한 페이지 당 나타낼 데이터의 개수.
+ * @param pageNumberLimit pageGroup 중 한 그룹당 들어갈 페이지 number의 개수. 기본값은 5.
+ * @param setActivityList 현재 페이지에서 보여줄 데이터를 설정하는 함수.
  */
 
-const Pagination = ({ totalCount, limit, setActivityList }: PaginationProp) => {
+const Pagination = ({
+  totalCount,
+  offsetLimit,
+  pageNumberLimit = 5,
+  setActivityList
+}: PaginationProp) => {
   const [currentPage, setCurrentPage] = useState(0);
   const [currentPageGroup, setCurrentPageGroup] = useState(0);
 
   // 총 페이지의 개수
-  const totalPage = Math.ceil(totalCount / limit);
+  const totalPage = Math.ceil(totalCount / offsetLimit);
 
   // 총 페이지 수에 대한 배열 만들기
   const pageNumber = new Array(totalPage).fill(0).map((num, i) => num + i);
@@ -25,33 +32,38 @@ const Pagination = ({ totalCount, limit, setActivityList }: PaginationProp) => {
   // 페이지 그룹 리스트
   const pageGroup = [];
 
-  for (let i = 0; i < pageNumber.length; i += 5) {
-    pageGroup.push(pageNumber.slice(i, i + 5));
+  for (let i = 0; i < pageNumber.length; i += pageNumberLimit) {
+    pageGroup.push(pageNumber.slice(i, i + pageNumberLimit));
   }
 
   // 현재 선택한 페이지 수를 저장
   const handlePageBtnClick = (e: MouseEvent<HTMLButtonElement>) => {
     const button = e.target as HTMLButtonElement;
-    setCurrentPage(+button.id);
-    setActivityList(+button.id, limit);
+    setCurrentPage(Number(button.id));
+    setActivityList(Number(button.id), offsetLimit);
   };
 
   // 왼쪽 arrow 버튼으로 이동 시 실행할 함수
   const handleLeftArrowBtnClick = () => {
-    if (currentPage !== 0 && (currentPage % 5) === 0) setCurrentPageGroup(currentPageGroup - 1);
+    const isFirstPage = (currentPage % pageNumberLimit) === 0;
+
     if (currentPage === 0) return;
+    if (isFirstPage) setCurrentPageGroup(currentPageGroup - 1);
+
     setCurrentPage(currentPage - 1);
-    setActivityList(currentPage - 1, limit);
+    setActivityList(currentPage - 1, offsetLimit);
   };
 
   // 오른쪽 arrow 버튼으로 이동 시 실행할 함수
   const handleRightArrowBtnClick = () => {
-    if (currentPage !== (pageNumber.length - 1) && (currentPage % 5) === 4) {
-      setCurrentPageGroup(currentPageGroup + 1);
-    }
-    if (currentPage === (pageNumber.length - 1)) return;
+    const lastPageNumber = pageNumber.length - 1;
+    const isLastPage = (currentPage % pageNumberLimit) === pageNumberLimit - 1;
+
+    if (currentPage === lastPageNumber) return;
+    if (isLastPage) setCurrentPageGroup(currentPageGroup + 1);
+
     setCurrentPage(currentPage + 1);
-    setActivityList(currentPage + 1, limit);
+    setActivityList(currentPage + 1, offsetLimit);
   };
 
   return (

--- a/src/components/mainpage/PopularActivityButton.tsx
+++ b/src/components/mainpage/PopularActivityButton.tsx
@@ -1,0 +1,25 @@
+interface PopularActivityButtonProps {
+  onLeftClick: () => void;
+  onRightClick: () => void;
+}
+
+const PopularActivityButton = ({ onLeftClick, onRightClick }: PopularActivityButtonProps) => {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onLeftClick}
+      >
+        <img src="/assets/arrow_left.svg" alt="left Arrow Btn" />
+      </button>
+      <button
+        type="button"
+        onClick={onRightClick}
+      >
+        <img src="/assets/arrow_right.svg" alt="right Arrow Btn" />
+      </button>
+    </div>
+  );
+};
+
+export default PopularActivityButton;

--- a/src/components/mainpage/PopularActivityCard.tsx
+++ b/src/components/mainpage/PopularActivityCard.tsx
@@ -1,25 +1,28 @@
+import { Link } from 'react-router-dom';
 import { ActivityCardProps } from './ActivityCard';
 
 const PopularActivityCard = ({ cardData }: ActivityCardProps) => {
   const { id, title, price, bannerImageUrl, rating, reviewCount } = cardData;
 
   return (
-    <div id={String(id)} className="relative">
-      <div className="absolute bottom-8 left-5 flex flex-col gap-5 w-[230px] text-white z-10">
-        <div className="flex gap-1">
-          <img src="/assets/bold_star.svg" alt="little-star" />
-          <p className="text-sm font-bold">{`${rating} (${reviewCount})`}</p>
+    <Link to={`/activity/${id}`}>
+      <div className="relative">
+        <div className="absolute bottom-8 left-5 flex flex-col gap-5 w-[230px] text-white z-10">
+          <div className="flex gap-1">
+            <img src="/assets/bold_star.svg" alt="little-star" />
+            <p className="text-sm font-bold">{`${rating} (${reviewCount})`}</p>
+          </div>
+          <div className="text-3xl font-bold">{title}</div>
+          <div className="flex items-center gap-1 text-xl font-bold">
+            {`₩ ${price}`}
+            <span className="text-sm text-gray-60">/인</span>
+          </div>
         </div>
-        <div className="text-3xl font-bold">{title}</div>
-        <div className="flex items-center gap-1 text-xl font-bold">
-          {`₩ ${price}`}
-          <span className="text-sm text-gray-60">/인</span>
+        <div className="relative w-96 h-96 bg-cover bg-center rounded-3xl" style={{ backgroundImage: `url('${bannerImageUrl}')` }}>
+          <div className="absolute inset-0 bg-black opacity-30 rounded-3xl" />
         </div>
       </div>
-      <div className="relative w-96 h-96 bg-cover bg-center rounded-3xl" style={{ backgroundImage: `url('${bannerImageUrl}')` }}>
-        <div className="absolute inset-0 bg-black opacity-30 rounded-3xl" />
-      </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/mainpage/PopularActivityList.tsx
+++ b/src/components/mainpage/PopularActivityList.tsx
@@ -1,13 +1,22 @@
-import { useState } from 'react';
-import { EXAMPLE_ACTIVITY } from '@/lib/utils/activity_mock_data';
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+import { ActivityInfo, ActivityResponse } from '@/types/mainPage';
 import PopularActivityCard from './PopularActivityCard';
 import PopularActivityButton from './PopularActivityButton';
 
 const PopularActivityList = () => {
   const [startIdx, setStartIdx] = useState(0);
-  const { activities } = EXAMPLE_ACTIVITY;
+  const [activity, setActivity] = useState<ActivityInfo[]>([]);
 
-  const pageActivityList = activities.slice(startIdx, startIdx + 3);
+  // 인기 체험 리스트 데이터를 불러오는 함수.
+  async function getPopularActivity() {
+    const res = await axiosInstance.get<ActivityResponse>(
+      '/activities?method=offset&sort=most_reviewed&page=1&size=10'
+    );
+    return res.data;
+  }
+
+  const pageActivityList = activity.slice(startIdx, startIdx + 3);
 
   const handleLeftClick = () => {
     if (startIdx === 0) return;
@@ -18,6 +27,14 @@ const PopularActivityList = () => {
     setStartIdx(startIdx + 1);
   };
 
+  useEffect(() => {
+    const fetchActivity = async () => {
+      const data = await getPopularActivity();
+      setActivity(data.activities);
+    };
+    fetchActivity();
+  }, []);
+
   return (
     <div className="mt-10 mb-[60px]">
       <div className="flex justify-between">
@@ -25,8 +42,8 @@ const PopularActivityList = () => {
         <PopularActivityButton onLeftClick={handleLeftClick} onRightClick={handleRightClick} />
       </div>
       <div className="grid grid-cols-3 gap-6 w-pc">
-        {pageActivityList.map((activity) => (
-          <PopularActivityCard key={activity.id} cardData={activity} />
+        {pageActivityList.map((info) => (
+          <PopularActivityCard key={info.id} cardData={info} />
         ))}
       </div>
     </div>

--- a/src/components/mainpage/PopularActivityList.tsx
+++ b/src/components/mainpage/PopularActivityList.tsx
@@ -1,20 +1,31 @@
+import { useState } from 'react';
 import { EXAMPLE_ACTIVITY } from '@/lib/utils/activity_mock_data';
 import PopularActivityCard from './PopularActivityCard';
+import PopularActivityButton from './PopularActivityButton';
 
 const PopularActivityList = () => {
+  const [startIdx, setStartIdx] = useState(0);
   const { activities } = EXAMPLE_ACTIVITY;
+
+  const pageActivityList = activities.slice(startIdx, startIdx + 3);
+
+  const handleLeftClick = () => {
+    if (startIdx === 0) return;
+    setStartIdx(startIdx - 1);
+  };
+  const handleRightClick = () => {
+    if (pageActivityList.length < 3) return;
+    setStartIdx(startIdx + 1);
+  };
 
   return (
     <div className="mt-10 mb-[60px]">
       <div className="flex justify-between">
         <div className="text-4xl font-bold mb-[33px]">🔥인기 체험</div>
-        <div>
-          <button type="button">left</button>
-          <button type="button">right</button>
-        </div>
+        <PopularActivityButton onLeftClick={handleLeftClick} onRightClick={handleRightClick} />
       </div>
       <div className="grid grid-cols-3 gap-6 w-pc">
-        {activities.map((activity) => (
+        {pageActivityList.map((activity) => (
           <PopularActivityCard key={activity.id} cardData={activity} />
         ))}
       </div>

--- a/src/components/mainpage/PopularActivityList.tsx
+++ b/src/components/mainpage/PopularActivityList.tsx
@@ -15,7 +15,7 @@ const PopularActivityList = () => {
       </div>
       <div className="grid grid-cols-3 gap-6 w-pc">
         {activities.map((activity) => (
-          <PopularActivityCard cardData={activity} />
+          <PopularActivityCard key={activity.id} cardData={activity} />
         ))}
       </div>
     </div>

--- a/src/lib/utils/activity_mock_data.ts
+++ b/src/lib/utils/activity_mock_data.ts
@@ -17,47 +17,61 @@ export const EXAMPLE_ACTIVITY = {
     {
       id: 901,
       userId: 292,
-      title: '0520의 체험',
+      title: '테스트용 체험2',
       description: '0520과 함께 체험해봐요!',
       category: '투어',
       price: 10000,
       address: '서울특별시 강남구 테헤란로 427',
-      bannerImageUrl: '/assets/banner.jpg',
+      bannerImageUrl: '/assets/samples/sub_img1.png',
       rating: 0,
       reviewCount: 0,
       createdAt: '2024-05-21T15:09:21.090Z',
       updatedAt: '2024-05-21T15:09:21.090Z'
     },
     {
-      id: 901,
+      id: 902,
       userId: 292,
-      title: '0520의 체험',
+      title: '테스트용 체험3',
       description: '0520과 함께 체험해봐요!',
       category: '투어',
       price: 10000,
       address: '서울특별시 강남구 테헤란로 427',
-      bannerImageUrl: '/assets/banner.jpg',
+      bannerImageUrl: '/assets/samples/sub_img2.png',
       rating: 0,
       reviewCount: 0,
       createdAt: '2024-05-21T15:09:21.090Z',
       updatedAt: '2024-05-21T15:09:21.090Z'
     },
     {
-      id: 901,
+      id: 903,
       userId: 292,
-      title: '0520의 체험',
+      title: '테스트용 체험4',
       description: '0520과 함께 체험해봐요!',
       category: '투어',
       price: 10000,
       address: '서울특별시 강남구 테헤란로 427',
-      bannerImageUrl: '/assets/banner.jpg',
+      bannerImageUrl: '/assets/samples/sub_img3.png',
+      rating: 0,
+      reviewCount: 0,
+      createdAt: '2024-05-21T15:09:21.090Z',
+      updatedAt: '2024-05-21T15:09:21.090Z'
+    },
+    {
+      id: 904,
+      userId: 292,
+      title: '테스트용 체험5',
+      description: '0520과 함께 체험해봐요!',
+      category: '투어',
+      price: 10000,
+      address: '서울특별시 강남구 테헤란로 427',
+      bannerImageUrl: '/assets/samples/sub_img4.png',
       rating: 0,
       reviewCount: 0,
       createdAt: '2024-05-21T15:09:21.090Z',
       updatedAt: '2024-05-21T15:09:21.090Z'
     }
   ],
-  totalCount: 4
+  totalCount: 5
 };
 
 export const EXAMPLE_MORE_ACTIVITIES = {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,5 +50,18 @@ module.exports = {
     },
   },
 
-  plugins: [],
+  plugins: [
+    function({ addUtilities }) {
+      const newUtilities = {
+        ".hide-scrollbar": {
+          "-ms-overflow-style": "none", // IE and Edge
+          "scrollbar-width": "none", // Firefox
+          "&::-webkit-scrollbar": {
+            display: "none", // Chrome, Safari, Opera
+          },
+        },
+      };
+      addUtilities(newUtilities);
+    },
+  ],
 };


### PR DESCRIPTION
## 💻 작업 내용

- 메인 페이지 인기 체험 리스트에 api를 연결, 불러온 데이터를 보여줄 수 있도록 구현
- 인기 체험은 reviewCount 순으로 한번에 3개씩 보여줄 수 있도록 구현했으며 서버에서 가져오는 인기 체험의 총 개수는 10개입니다.
- 스크롤 바를 숨길 수 있도록 tailwind.config 파일에 유틸리티 클래스로 추가했습니다.

++ 5/31 금 - 멘토님의 피드백에 따라 코드를 수정했습니다. 크게 변동된 부분은 없어 기존에 작성하셨던 코드는 문제없이 잘 동작할 것 같습니다. 혹시 에러가 발생하는 부분이 생긴다면 말씀해주세요!

## 🖼️ 스크린샷

![스크린샷 2024-05-31 152018](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/7feadad2-bb15-4710-ac6c-c3a274da94f3)
![스크린샷 2024-05-31 152038](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/80acc5cb-db75-4b18-a8e9-2bd9fc6391b3)


## 🚨 관련 이슈 및 참고 사항

- 체험 리스트에서 다음 내용이 없다면 버튼이 비활성화 되는 부분에 대해서 다음번에 추가해둘 예정입니다.
- 구현하시다가 의도치 않게 스크롤 바가 생기는 부분이 있다면 className에 hide-scrollbar를 추가해 주세요!
