### PR TITLE
[GNTF-46] 나의 정보 페이지 유효성 검사 기능, 이미지 업로드 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
-        "react-scripts": "5.0.1"
+        "react-scripts": "5.0.1",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -18753,6 +18754,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -19903,6 +19912,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
+      "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/src/api/editMyInformation.ts
+++ b/src/api/editMyInformation.ts
@@ -1,0 +1,37 @@
+import axiosInstance from '@/lib/axiosInstance';
+
+export interface EditMyInformationType {
+  nickname: string;
+  profileImageUrl: string | null;
+  newPassword: string;
+}
+
+class EditMyInformationError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super('EditInforMation Error');
+    this.status = status;
+    this.name = 'EditInformationError';
+  }
+}
+
+const editMyInformation = async ({
+  nickname,
+  profileImageUrl,
+  newPassword,
+}: EditMyInformationType): Promise<any> => {
+  const response = await axiosInstance.patch('/users/me', {
+    nickname,
+    profileImageUrl,
+    newPassword,
+  });
+
+  if (response.status !== 200) {
+    throw new EditMyInformationError(response.status);
+  }
+
+  return response.data;
+};
+
+export default editMyInformation;

--- a/src/api/uploadProfileImage.ts
+++ b/src/api/uploadProfileImage.ts
@@ -1,0 +1,22 @@
+import axiosInstance from '@/lib/axiosInstance';
+
+const uploadProfileImage = async (file: File): Promise<any> => {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  try {
+    const response = await axiosInstance.post('/users/me/image', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    console.log(response);
+    return response.data;
+  } catch (error) {
+    console.error('Error Upload Image');
+    throw error;
+  }
+};
+
+export default uploadProfileImage;

--- a/src/components/common/profile/InformationNoProfileImage.tsx
+++ b/src/components/common/profile/InformationNoProfileImage.tsx
@@ -1,11 +1,70 @@
-const InformationNoImage = ({ nickname }: { nickname: string }) => {
+import { ChangeEvent, useRef } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import uploadProfileImage from '@/api/uploadProfileImage';
+
+const InformationNoImage = ({
+  nickname,
+  uploadedImage = null,
+  setUploadedImage = () => null,
+}: {
+  nickname: string;
+  uploadedImage: string | null;
+  setUploadedImage: React.Dispatch<React.SetStateAction<string | null>>;
+}) => {
   const nicknameInitial = nickname[0];
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const mutation = useMutation({
+    mutationFn: uploadProfileImage,
+    onSuccess: (data) => {
+      setUploadedImage(data.profileImageUrl);
+    },
+    onError: (error) => {
+      console.error('Failed to upload image:', error);
+    },
+  });
+
+  const handleFileInputClick = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  const onChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const imageUrl = URL.createObjectURL(file);
+      setUploadedImage(imageUrl);
+
+      mutation.mutate(file);
+    }
+  };
+
   return (
-    <div className="w-40 h-40 bg-slate-400 rounded-full flex items-center justify-center text-white">
-      {nicknameInitial}
-      <div className="absolute p-[10px] w-11 h-11 inline-flex items-start bottom-0 right-3 z-10 rounded-full bg-green-80">
+    <div className="relative w-40 h-40 bg-slate-400 rounded-full flex items-center justify-center text-white">
+      {uploadedImage ? (
+        <img
+          src={uploadedImage}
+          alt="Uploaded"
+          className="w-full h-full object-cover rounded-full"
+        />
+      ) : (
+        <span>{nicknameInitial}</span>
+      )}
+
+      <div
+        onClick={handleFileInputClick}
+        className="absolute p-[10px] w-11 h-11 inline-flex items-start top-[115px] right-3 z-10 rounded-full bg-green-80 cursor-pointer"
+      >
         <img className="w-6 h-6" src="/assets/pen_icon.svg" alt="penIcon" />
       </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        onChange={onChangeImage}
+        className="absolute inset-0 opacity-0 cursor-pointer"
+      />
     </div>
   );
 };

--- a/src/components/common/profile/Profile.tsx
+++ b/src/components/common/profile/Profile.tsx
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import getUserInfo from '@/api/getUserInfo';
-import PageMenu from './PageMenu';
 
+import PageMenu from './PageMenu';
 import ProfileImage from './ProfileImage';
 
-const Profile = () => {
+const Profile = ({
+  uploadedImage = null,
+  setUploadedImage,
+}: {
+  uploadedImage?: string | null;
+  setUploadedImage?: React.Dispatch<React.SetStateAction<string | null>>;
+}) => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['user'],
     queryFn: getUserInfo,
@@ -18,13 +24,14 @@ const Profile = () => {
     return <div>프로필을 불러오는데 실패했습니다</div>;
   }
   return (
-    // 여기에서 profileImage에 api에서 받아온 프로필을 설정할 수 있음
     <div className="flex sm:hidden md:w-[251px] lg:w-96 p-6 flex-col justify-center items-start gap-6 border rounded-xl border-gray-50 bg-white shadow-md self-start">
       <div className="flex justify-center items-start gap-[227px] self-stretch">
         <div className="flex flex-col justify-center items-center gap-6">
           <ProfileImage
             nickname={data.nickname}
             profileImageUrl={data.profileImageUrl}
+            uploadedImage={uploadedImage}
+            setUploadedImage={setUploadedImage}
           />
         </div>
       </div>

--- a/src/components/common/profile/ProfileImage.tsx
+++ b/src/components/common/profile/ProfileImage.tsx
@@ -1,25 +1,66 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
+import uploadProfileImage from '@/api/uploadProfileImage';
+
 import InformationNoImage from './InformationNoProfileImage';
 
 const ProfileImage = ({
   nickname,
   profileImageUrl,
+  uploadedImage = null,
+  setUploadedImage = () => null,
 }: {
   nickname: string;
   profileImageUrl: string;
+  uploadedImage?: string | null;
+  setUploadedImage?: React.Dispatch<React.SetStateAction<string | null>>;
 }) => {
-  if (!profileImageUrl) {
-    return <InformationNoImage nickname={nickname} />;
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      try {
+        const imageData = await uploadProfileImage(file);
+        setUploadedImage(imageData.profileImageUrl);
+      } catch (error) {
+        console.error('Failed to upload image:', error);
+      }
+    }
+  };
+
+  const handlePenClick = () => {
+    const fileInput = document.getElementById('file-input');
+    if (fileInput) fileInput.click();
+  };
+
+  if (!profileImageUrl && !uploadedImage) {
+    return (
+      <InformationNoImage
+        nickname={nickname}
+        setUploadedImage={setUploadedImage}
+        uploadedImage={uploadedImage}
+      />
+    );
   }
+
   return (
     <div
       className="relative w-40 h-40 shrink-0 rounded-full shadow-md bg-cover bg-no-repeat bg-center"
       style={{
-        backgroundImage: `url(${profileImageUrl})`,
+        backgroundImage: `url(${uploadedImage || profileImageUrl})`,
         backgroundColor: '#E3E5E8',
       }}
     >
-      <div className="absolute p-[10px] w-11 h-11 inline-flex items-start bottom-0 right-3 z-10 rounded-full bg-green-80">
+      <input
+        id="file-input"
+        type="file"
+        onChange={handleFileChange}
+        style={{ display: 'none' }}
+        accept="image/*"
+      />
+
+      <div
+        className="absolute p-[10px] w-11 h-11 inline-flex items-start bottom-0 right-3 z-10 rounded-full bg-green-80 cursor-pointer"
+        onClick={handlePenClick}
+      >
         <img className="w-6 h-6" src="/assets/pen_icon.svg" alt="penIcon" />
       </div>
     </div>

--- a/src/components/common/profile/ProfileImage.tsx
+++ b/src/components/common/profile/ProfileImage.tsx
@@ -47,6 +47,7 @@ const ProfileImage = ({
       style={{
         backgroundImage: `url(${uploadedImage || profileImageUrl})`,
         backgroundColor: '#E3E5E8',
+        backgroundSize: 'contain',
       }}
     >
       <input

--- a/src/components/header/HeaderProfile.tsx
+++ b/src/components/header/HeaderProfile.tsx
@@ -1,5 +1,6 @@
 import getUserInfo from '@/api/getUserInfo';
 import { useQuery } from '@tanstack/react-query';
+
 import HeaderProfileImage from './HeaderProfileImage';
 
 const HeaderProfile = () => {

--- a/src/components/header/HeaderProfileImage.tsx
+++ b/src/components/header/HeaderProfileImage.tsx
@@ -14,7 +14,10 @@ const HeaderProfileImage = ({
   return (
     <div
       className="w-8 h-8 rounded-full overflow-hidden bg-cover bg-no-repeat"
-      style={{ backgroundImage: `url(${profileImageUrl})` }}
+      style={{
+        backgroundImage: `url(${profileImageUrl})`,
+        backgroundSize: 'contain',
+      }}
     />
   );
 };

--- a/src/components/header/HeaderProfileImage.tsx
+++ b/src/components/header/HeaderProfileImage.tsx
@@ -11,7 +11,12 @@ const HeaderProfileImage = ({
   if (!profileImageUrl) {
     return <NoProfileImage nickname={nickname} />;
   }
-  return <img src={profileImageUrl} alt="Profile" />;
+  return (
+    <div
+      className="w-8 h-8 rounded-full overflow-hidden bg-cover bg-no-repeat"
+      style={{ backgroundImage: `url(${profileImageUrl})` }}
+    />
+  );
 };
 
 export default HeaderProfileImage;

--- a/src/components/myPage/MyPageForm.tsx
+++ b/src/components/myPage/MyPageForm.tsx
@@ -57,6 +57,12 @@ const MyPageForm = ({ uploadedImage }: { uploadedImage: string | null }) => {
               ...prev,
               nicknameErrorMessage: '닉네임을 입력해주세요.',
             }));
+            if (newPassword.length === 0) {
+              setEditInformationErrorMessage((prev) => ({
+                ...prev,
+                passwordErrorMessageErrorMessage: '비밀번호를 입력해주세요.',
+              }));
+            }
           } else if (nickname.length > 10) {
             setEditInformationErrorMessage((prev) => ({
               ...prev,

--- a/src/components/myPage/MyPageForm.tsx
+++ b/src/components/myPage/MyPageForm.tsx
@@ -1,14 +1,109 @@
-import { useState, ChangeEvent, FormEvent } from 'react';
+import { useState, ChangeEvent, FormEvent, useEffect } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import getUserInfo from '@/api/getUserInfo';
+
+import editMyInformation from '@/api/editMyInformation';
+import queryClient from '@/lib/queryClient';
+import { EditInformationErrorMessageType } from '@/types/signupPage';
+import { AxiosError } from 'axios';
 import MyPageInputBox from './MyPageInputBox';
 
-const MyPageForm = () => {
+const MyPageForm = ({ uploadedImage }: { uploadedImage: string | null }) => {
   const [inputs, setInputs] = useState({
     nickname: '',
     email: '',
-    password: '',
-    passwordConfirm: '',
+    newPassword: '',
+    newPasswordConfirm: '',
   });
-  const { nickname, email, password, passwordConfirm } = inputs;
+  const [editInformationErrorMessage, setEditInformationErrorMessage] =
+    useState<EditInformationErrorMessageType>({
+      nicknameErrorMessage: null,
+      passwordErrorMessage: null,
+      passwordConfirmErrorMessage: null,
+      unexpectedErrorMessage: null,
+    });
+  const PASSWORD_MIN_LENGTH = 8;
+  const { data, isSuccess } = useQuery({
+    queryKey: ['user'],
+    queryFn: getUserInfo,
+  });
+
+  const newPasswordConfirmFocusOut = () => {
+    if (inputs.newPassword !== inputs.newPasswordConfirm) {
+      setEditInformationErrorMessage((prev) => ({
+        ...prev,
+        passwordErrorMessage: '비밀번호가 일치하지 않습니다.',
+      }));
+    } else {
+      setEditInformationErrorMessage((prev) => ({
+        ...prev,
+        passwordErrorMessage: null,
+      }));
+    }
+  };
+
+  const { mutate } = useMutation({
+    mutationFn: editMyInformation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user'] });
+    },
+    onError: (error: AxiosError) => {
+      if (error.response) {
+        const { nickname, newPassword } = inputs;
+        if (error.request.status === 400) {
+          // 닉네임 확인
+          if (nickname.length === 0) {
+            setEditInformationErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: '닉네임을 입력해주세요.',
+            }));
+          } else if (nickname.length > 10) {
+            setEditInformationErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: '닉네임은 10자 이하로 작성해주세요.',
+            }));
+          } else {
+            setEditInformationErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: null,
+            }));
+            // 비밀번호 확인
+            if (newPassword.length === 0) {
+              setEditInformationErrorMessage((prev) => ({
+                ...prev,
+                passwordErrorMessage: '비밀번호를 입력해주세요.',
+              }));
+            } else if (
+              newPassword.length > 0 &&
+              newPassword.length < PASSWORD_MIN_LENGTH
+            ) {
+              setEditInformationErrorMessage((prev) => ({
+                ...prev,
+                passwordErrorMessage: '8자 이상 작성해 주세요.',
+              }));
+            } else {
+              setEditInformationErrorMessage((prev) => ({
+                ...prev,
+                passwordErrorMessage: null,
+              }));
+            }
+          }
+        }
+      }
+    },
+  });
+
+  useEffect(() => {
+    if (data) {
+      setInputs({
+        nickname: data.nickname,
+        email: data.email,
+        newPassword: '',
+        newPasswordConfirm: '',
+      });
+    }
+  }, [isSuccess, data]);
+  const { nickname, email, newPassword, newPasswordConfirm } = inputs;
   const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     const { value, name } = e.target;
     setInputs({
@@ -19,8 +114,42 @@ const MyPageForm = () => {
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(inputs);
+    const profileImageUrl = uploadedImage ?? data?.profileImageUrl ?? '';
+    if (newPassword !== newPasswordConfirm) {
+      if (newPassword.length > 0 && newPassword.length < PASSWORD_MIN_LENGTH) {
+        setEditInformationErrorMessage((prev) => ({
+          ...prev,
+          passwordErrorMessage: '8자 이상 작성해 주세요.',
+        }));
+      }
+      if (newPasswordConfirm.length === 0) {
+        setEditInformationErrorMessage((prev) => ({
+          ...prev,
+          passwordConfirmErrorMessage: '비밀번호 확인값을 입력해주세요.',
+        }));
+      } else {
+        setEditInformationErrorMessage((prev) => ({
+          ...prev,
+          passwordErrorMessage: '비밀번호가 일치하지 않습니다.',
+        }));
+      }
+
+      return;
+    }
+
+    // 비밀번호가 일치하면 에러 메시지 초기화
+    setEditInformationErrorMessage((prev) => ({
+      ...prev,
+      passwordConfirmErrorMessage: null,
+    }));
+    mutate({
+      nickname,
+      profileImageUrl,
+      newPassword,
+    });
   };
+
+  console.log(editInformationErrorMessage);
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-between font-bold">
@@ -28,7 +157,7 @@ const MyPageForm = () => {
         <button
           type="submit"
           form="myPageForm"
-          className="text-[16px] text-white bg-[#112211] px-8 py-[10px] rounded"
+          className="text-[16px] text-white bg-[#112211] px-8 py-[10px] rounded cursor-pointer"
         >
           저장하기
         </button>
@@ -45,27 +174,33 @@ const MyPageForm = () => {
           value={nickname}
           labelName="닉네임"
           inputType="text"
+          editInformationErrorMessage={editInformationErrorMessage}
+          setEditInformationErrorMessage={setEditInformationErrorMessage}
         />
         <MyPageInputBox
           inputName="email"
-          onChangeInput={onChangeInput}
           value={email}
           labelName="이메일"
           inputType="email"
         />
         <MyPageInputBox
-          inputName="password"
+          inputName="newPassword"
           onChangeInput={onChangeInput}
-          value={password}
+          value={newPassword}
           labelName="비밀번호"
           inputType="password"
+          editInformationErrorMessage={editInformationErrorMessage}
+          setEditInformationErrorMessage={setEditInformationErrorMessage}
         />
         <MyPageInputBox
-          inputName="passwordConfirm"
+          inputName="newPasswordConfirm"
           onChangeInput={onChangeInput}
-          value={passwordConfirm}
+          value={newPasswordConfirm}
           labelName="비밀번호 재입력"
           inputType="password"
+          editInformationErrorMessage={editInformationErrorMessage}
+          setEditInformationErrorMessage={setEditInformationErrorMessage}
+          onFocusOut={newPasswordConfirmFocusOut}
         />
       </form>
     </div>

--- a/src/components/myPage/MyPageForm.tsx
+++ b/src/components/myPage/MyPageForm.tsx
@@ -114,7 +114,7 @@ const MyPageForm = ({ uploadedImage }: { uploadedImage: string | null }) => {
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const profileImageUrl = uploadedImage ?? data?.profileImageUrl ?? '';
+    const profileImageUrl = uploadedImage ?? data?.profileImageUrl ?? null;
     if (newPassword !== newPasswordConfirm) {
       if (newPassword.length > 0 && newPassword.length < PASSWORD_MIN_LENGTH) {
         setEditInformationErrorMessage((prev) => ({

--- a/src/components/myPage/MyPageForm.tsx
+++ b/src/components/myPage/MyPageForm.tsx
@@ -52,17 +52,19 @@ const MyPageForm = ({ uploadedImage }: { uploadedImage: string | null }) => {
         const { nickname, newPassword } = inputs;
         if (error.request.status === 400) {
           // 닉네임 확인
+
+          if (nickname.length === 0 && newPassword.length === 0) {
+            setEditInformationErrorMessage((prev) => ({
+              ...prev,
+              nicknameErrorMessage: '닉네임을 입력해주세요.',
+              passwordErrorMessage: '비밀번호를 입력해주세요.',
+            }));
+          }
           if (nickname.length === 0) {
             setEditInformationErrorMessage((prev) => ({
               ...prev,
               nicknameErrorMessage: '닉네임을 입력해주세요.',
             }));
-            if (newPassword.length === 0) {
-              setEditInformationErrorMessage((prev) => ({
-                ...prev,
-                passwordErrorMessageErrorMessage: '비밀번호를 입력해주세요.',
-              }));
-            }
           } else if (nickname.length > 10) {
             setEditInformationErrorMessage((prev) => ({
               ...prev,

--- a/src/components/myPage/MyPageInputBox.tsx
+++ b/src/components/myPage/MyPageInputBox.tsx
@@ -1,31 +1,102 @@
 import { ChangeEvent } from 'react';
+import { EditInformationErrorMessageType } from '@/types/signupPage';
 import MyPageInputLabel from './MyPageInputLabel';
 
 interface MyPageInputBoxProps {
   inputName: string;
-  onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChangeInput?: (e: ChangeEvent<HTMLInputElement>) => void;
   value: string;
   labelName: string;
   inputType: string;
+  editInformationErrorMessage?: EditInformationErrorMessageType | null;
+  setEditInformationErrorMessage?: React.Dispatch<
+  React.SetStateAction<EditInformationErrorMessageType>
+  >;
+  onFocusOut?: () => void;
 }
+
 const MyPageInputBox = ({
   inputName,
   onChangeInput,
   value,
   labelName,
   inputType,
+  editInformationErrorMessage,
+  setEditInformationErrorMessage,
+  onFocusOut,
 }: MyPageInputBoxProps) => {
+  let borderColorClass = '';
+
+  const onClickInput = () => {
+    if (setEditInformationErrorMessage) {
+      if (inputName === 'nickname') {
+        setEditInformationErrorMessage((prev) => ({
+          ...prev,
+          nicknameErrorMessage: null,
+        }));
+      } else if (inputName === 'newPassword') {
+        setEditInformationErrorMessage((prev) => ({
+          ...prev,
+          passwordErrorMessage: null,
+        }));
+      } else if (inputName === 'newPasswordConfirm') {
+        setEditInformationErrorMessage((prev) => ({
+          ...prev,
+          passwordConfirmErrorMessage: null,
+        }));
+      }
+    }
+  };
+
+  if (
+    inputName === 'nickname' &&
+    editInformationErrorMessage?.nicknameErrorMessage
+  ) {
+    borderColorClass = 'border-red-40';
+  } else if (
+    inputName === 'newPassword' &&
+    editInformationErrorMessage?.passwordErrorMessage
+  ) {
+    borderColorClass = 'border-red-40';
+  } else if (
+    inputName === 'newPasswordConfirm' &&
+    editInformationErrorMessage?.passwordConfirmErrorMessage
+  ) {
+    borderColorClass = 'border-red-40';
+  }
+
   return (
     <div className="flex flex-col w-[792px] gap-4">
       <MyPageInputLabel labelName={labelName} />
       <input
-        className="w-full py-4 pl-4 border border-gray-50 rounded"
+        className={`w-full py-4 pl-4 border border-gray-50 rounded ${borderColorClass}`}
         type={inputType}
         id={inputName}
         onChange={onChangeInput}
         value={value}
         name={inputName}
+        onBlur={inputName === 'newPasswordConfirm' ? onFocusOut : undefined}
+        onClick={onClickInput}
       />
+      {inputName === 'nickname' &&
+        editInformationErrorMessage?.nicknameErrorMessage && (
+          <div className="text-red-40 text-xs ml-1">
+            {editInformationErrorMessage.nicknameErrorMessage}
+          </div>
+      )}
+
+      {inputName === 'newPassword' &&
+        editInformationErrorMessage?.passwordErrorMessage && (
+          <div className="text-red-40 text-xs ml-1">
+            {editInformationErrorMessage.passwordErrorMessage}
+          </div>
+      )}
+      {inputName === 'newPasswordConfirm' &&
+        editInformationErrorMessage?.passwordConfirmErrorMessage && (
+          <div className="text-red-40 text-xs ml-1">
+            {editInformationErrorMessage.passwordConfirmErrorMessage}
+          </div>
+      )}
     </div>
   );
 };

--- a/src/components/signup/SignupInputBox.tsx
+++ b/src/components/signup/SignupInputBox.tsx
@@ -127,7 +127,7 @@ const SignupInputBox = ({
           <div className="text-red-40 text-xs ml-1">
             {signupErrorMessage.passwordConfirmErrorMessage}
           </div>
-        )}
+      )}
     </div>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import queryClient from './lib/queryClient';
 
-const queryClient = new QueryClient();
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,5 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+export default queryClient;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MyPageForm from '@/components/myPage/MyPageForm';
 import Profile from '../components/common/profile/Profile';
 
-const MyPage = () => (
-  <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[65px]">
-    <Profile />
-    <MyPageForm />
-  </div>
-);
+const MyPage = () => {
+  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  return (
+    <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[65px]">
+      <Profile
+        uploadedImage={uploadedImage}
+        setUploadedImage={setUploadedImage}
+      />
+      <MyPageForm uploadedImage={uploadedImage} />
+    </div>
+  );
+};
 
 export default MyPage;

--- a/src/pages/ReservationsPage.tsx
+++ b/src/pages/ReservationsPage.tsx
@@ -46,11 +46,11 @@ const ReservationsPage = () => {
     setSelectedBooking(null);
   };
   if (isLoading) {
-    return <div>프로필을 불러오고 있습니다</div>;
+    return <div>예약 목록을 불러오고 있습니다...</div>;
   }
 
   if (isError || !data) {
-    return <div>프로필을 불러오는데 실패했습니다</div>;
+    return <div>예약 목록을 불러오는데 실패했습니다</div>;
   }
 
   return (

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface UploadImageState {
+  uploadedImage: string | null;
+  setUploadedImage: (imageUrl: string | null) => void;
+}
+
+const useUploadImageStore = create<UploadImageState>((set) => ({
+  uploadedImage: null,
+  setUploadedImage: (imageUrl) => set({ uploadedImage: imageUrl }),
+}));
+
+export default useUploadImageStore;

--- a/src/types/signupPage.ts
+++ b/src/types/signupPage.ts
@@ -5,3 +5,10 @@ export interface SignupErrorType {
   passwordConfirmErrorMessage: string | null;
   unexpectedErrorMessage: string | null;
 }
+
+export interface EditInformationErrorMessageType {
+  nicknameErrorMessage: string | null;
+  passwordErrorMessage: string | null;
+  passwordConfirmErrorMessage: string | null;
+  unexpectedErrorMessage: string | null;
+}


### PR DESCRIPTION
## 💻 작업 내용

- 나의 정보 페이지에서 유효성 검사를 하고 통과하면 정보를 변경합니다
- 프로필 이미지 변경이 가능합니다(저장하기전에 연속해서 변경 가능합니다)

> 상세설명
- 나의 정보 페이지에서 닉네임, 비밀번호, 프로필 이미지 변경이 가능합니다
- 이미지를 선택하지 않고 나의 정보를 변경하면 기존 이미지가 유지됩니다
- 이메일과 닉네임값은 미리 채워져있으며 이메일은 변경 불가능합니다
- 정보를 수정하면 헤더 프로필도 동시에 바뀝니다
</br>

> > 에러메시지 상세(인풋창 클릭시 에러메시지가 없어집니다)

- 닉네임이 없을경우: "닉네임을 입력해주세요."
- 닉네임의 길이가 10자를 초과할 경우 : '닉네임은 10자 이하로 작성해주세요.'
</br>

- 비밀번호가 없을 경우 : '비밀번호를 입력해주세요.'
- 비밀번호의 길이가 8보다 작을경우 :  '8자 이상 작성해 주세요.'
</br>

- 비밀번호값이 존재하고 비밀번호 확인값이 없을경우 : 비밀번호 확인값을 입력해주세요.
- 비밀번호값과 비밀번호 확인값 둘다 존재하지만 다를경우: 비밀번호가 일치하지 않습니다.
</br>

- 비밀번호확인 input에서 포커스 아웃시 비밀번호값과 비밀번호 확인값이 다를경우 : 비밀번호가 일치하지 않습니다.

## 🖼️ 스크린샷

![Global Nomad - Chrome 2024-05-31 18-47-02](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/64bf1c56-e505-4ad6-9e04-34f38b601df5)




## 🚨 관련 이슈 및 참고 사항

- 크롬창만 캡쳐해서 이미지 파일올라가는 장면은 찍히지 않았습니다 실제로는 로컬환경에 있는 이미지를 선택해서 프로필 이미지 변경이 가능합니다
