### PR TITLE
[GNTF-51] MyActivityPage에 api 및 페이지 연결

### DIFF
--- a/src/components/myActivity/ReservationCard.tsx
+++ b/src/components/myActivity/ReservationCard.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import priceToWon from '@/utils/priceToWon';
 import CustomKebabMenu from './CustomKebabMenu';
 
@@ -17,6 +19,8 @@ export interface Activity {
 }
 
 const ReservationCard = ({ activity }: { activity: Activity }) => {
+  const navigate = useNavigate();
+
   return (
     <li className="rounded-3xl flex w-full h-[12.75rem] md:h-[9.75rem] sm:h-32 sm:min-w-[21.5rem] shadow-md">
       <div className="rounded-l-3xl w-[12.75rem] h-[12.75rem] md:w-[9.75rem] md:h-[9.75rem] sm:w-32 sm:h-32">
@@ -46,7 +50,13 @@ const ReservationCard = ({ activity }: { activity: Activity }) => {
           </p>
           <CustomKebabMenu
             options={[
-              { label: '수정하기', onClick: () => console.log('안녕') },
+              {
+                label: '수정하기',
+                onClick: () =>
+                  navigate('/my-activity/modify', {
+                    state: { ...activity },
+                  }),
+              },
               { label: '삭제하기', onClick: () => console.log('안녕') },
             ]}
           />

--- a/src/components/myActivity/ReservationCard.tsx
+++ b/src/components/myActivity/ReservationCard.tsx
@@ -1,7 +1,7 @@
 import priceToWon from '@/utils/priceToWon';
 import CustomKebabMenu from './CustomKebabMenu';
 
-interface Activity {
+export interface Activity {
   id: number;
   userId: number;
   title: string;
@@ -15,52 +15,6 @@ interface Activity {
   createdAt: string;
   updatedAt: string;
 }
-
-// 목업데이터
-export const activities: Activity[] = [
-  {
-    id: 1,
-    userId: 1,
-    title: '함께 배우면 즐거운 스트릿 댄스',
-    description: '예약에 대한 설명',
-    category: '예약_카테고리',
-    price: 10000,
-    address: '예약_주소',
-    bannerImageUrl: 'https://picsum.photos/200/300',
-    rating: 4.9,
-    reviewCount: 293,
-    createdAt: '2024-05-25T14:47:09.208Z',
-    updatedAt: '2024-05-25T14:47:09.208Z',
-  },
-  {
-    id: 2,
-    userId: 2,
-    title: 'B-boy 댄스 배우기',
-    description: '예약에 대한 설명',
-    category: '예약_카테고리',
-    price: 10000,
-    address: '예약_주소',
-    bannerImageUrl: 'https://picsum.photos/200/300',
-    rating: 4.9,
-    reviewCount: 293,
-    createdAt: '2024-05-24T10:30:00.000Z',
-    updatedAt: '2024-05-24T10:30:00.000Z',
-  },
-  {
-    id: 3,
-    userId: 1,
-    title: '발레 배우기',
-    description: '예약에 대한 설명',
-    category: '예약_카테고리',
-    price: 10000,
-    address: '예약_주소',
-    bannerImageUrl: 'https://picsum.photos/200/300',
-    rating: 4.9,
-    reviewCount: 293,
-    createdAt: '2024-05-23T09:00:00.000Z',
-    updatedAt: '2024-05-23T09:00:00.000Z',
-  },
-];
 
 const ReservationCard = ({ activity }: { activity: Activity }) => {
   return (

--- a/src/pages/ModifyActivityPage.tsx
+++ b/src/pages/ModifyActivityPage.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
-const ModifyActivityPage = () => <div>체험 수정 페이지!</div>;
-
+const ModifyActivityPage = () => {
+  const location = useLocation();
+  console.log(location.state);
+  return <div>체험 수정 페이지!</div>;
+};
 export default ModifyActivityPage;

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -1,9 +1,30 @@
 import Profile from '@/components/common/profile/Profile';
-import ReservationCard, {
-  activities,
-} from '@/components/myActivity/ReservationCard';
+import ReservationCard, { Activity } from '@/components/myActivity/ReservationCard';
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/lib/axiosInstance';
+
+interface ApiResponse {
+  cursorId: number;
+  totalCount: number;
+  activities: Activity[];
+}
 
 const MyActivityPage = () => {
+  const [activities, setActivities] = useState<Activity[]>([]);
+
+  useEffect(() => {
+    const fetchActivities = async () => {
+      try {
+        const response = await axiosInstance.get<ApiResponse>('/my-activities');
+        setActivities(response.data.activities);
+      } catch (error) {
+        console.error('Error fetching activities:', error);
+      }
+    };
+
+    fetchActivities();
+  }, []);
+
   return (
     <section className=" bg-gray-10 px-4 py-16">
       <div className="flex max-w-[75rem] mx-auto gap-6 items-start">
@@ -11,9 +32,7 @@ const MyActivityPage = () => {
         {/* 내 체험 관리 헤더 */}
         <div className="w-full">
           <div className="min-w-[21.5rem] flex justify-between mb-6">
-            <h2 className=" text-black font-bold text-[32px] self-start">
-              내 체험 관리
-            </h2>
+            <h2 className=" text-black font-bold text-[32px] self-start">내 체험 관리</h2>
             <button
               type="button"
               className="flex min-w-[7.5rem] h-12 p-2.5 justify-center items-center gap-1 self-stretch rounded bg-[#121] text-white"

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -2,6 +2,7 @@ import Profile from '@/components/common/profile/Profile';
 import ReservationCard, { Activity } from '@/components/myActivity/ReservationCard';
 import { useEffect, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
+import { useNavigate } from 'react-router-dom';
 
 interface ApiResponse {
   cursorId: number;
@@ -10,6 +11,7 @@ interface ApiResponse {
 }
 
 const MyActivityPage = () => {
+  const navigate = useNavigate();
   const [activities, setActivities] = useState<Activity[]>([]);
 
   useEffect(() => {
@@ -25,6 +27,10 @@ const MyActivityPage = () => {
     fetchActivities();
   }, []);
 
+  const handleAssignClick = () => {
+    navigate('/my-activity/assign');
+  };
+
   return (
     <section className=" bg-gray-10 px-4 py-16">
       <div className="flex max-w-[75rem] mx-auto gap-6 items-start">
@@ -36,6 +42,7 @@ const MyActivityPage = () => {
             <button
               type="button"
               className="flex min-w-[7.5rem] h-12 p-2.5 justify-center items-center gap-1 self-stretch rounded bg-[#121] text-white"
+              onClick={handleAssignClick}
             >
               체험 등록하기
             </button>


### PR DESCRIPTION
## 💻 작업 내용
- MyActivityPage에 목업데이터 remove 후 api 연결
- MyActivityPage에서 '체험 등록하기' 버튼에 my-activity/assign페이지 연결
- MyActivityPage에서 '수정하기' 케밥버튼에 my-activity/modify페이지 연결 및 데이터 넘겨줌

## 🖼️ 스크린샷
### MyActivityPage에 목업데이터 remove 후 api 연결
<img width="1440" alt="스크린샷 2024-06-02 오후 11 55 55" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/22323cc9-c041-4183-bbff-7e3a2200e6eb">

### MyActivityPage에서 '수정하기' 케밥버튼에 my-activity/modify페이지 연결 및 데이터 넘겨줌
<img width="1439" alt="스크린샷 2024-06-02 오후 11 55 11" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/2bbccca5-71da-49fc-a1cb-e096c0ed5697">

## 🚨 관련 이슈 및 참고 사항
- MyActivityPage에서 '삭제하기' 케밥버튼에 “삭제하시겠습니까?” 모달창을 띄우고, 모달창에서 “예”를 누르면 해당 체험이 삭제가 되도록 해야하는 작업 남음 (해당작업 피그마에는 없고, 노션 기획 요구사항에만 있는 내용)