### PR TITLE
[GNTF-52] 메인 페이지 필터, 검색 기능 구현 및 api 연결

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -12,6 +12,7 @@ import AssignActivityPage from './pages/AssignActivityPage';
 import ModifyActivityPage from './pages/ModifyActivityPage';
 import ReserveStatusPage from './pages/ReserveStatusPage';
 import Error404 from './pages/Error404';
+import SearchResultPage from './pages/SearchResultPage';
 
 const AppRouter = () => (
   <BrowserRouter>
@@ -22,6 +23,8 @@ const AppRouter = () => (
       <Route path="/" element={<Layout />}>
         {/* 메인 페이지 */}
         <Route index element={<MainPage />} />
+        {/* 메인 검색 페이지 */}
+        <Route path="search" element={<SearchResultPage />} />
         {/* 체험 상세 페이지 */}
         <Route path="activity/:id" element={<ActivityPage />} />
         {/* 내 정보 */}

--- a/src/api/getCurrentPageActivity.ts
+++ b/src/api/getCurrentPageActivity.ts
@@ -10,7 +10,7 @@ const getCurrentPageActivity = async (
   pageNum: number,
   size: number,
   category?: string,
-  keyword?: string
+  sort?: string,
 ): Promise<ActivityResponse> => {
   const urlSearchParams = new URLSearchParams({
     method: 'offset',
@@ -19,7 +19,7 @@ const getCurrentPageActivity = async (
   });
 
   if (category) urlSearchParams.append('category', category);
-  if (keyword) urlSearchParams.append('keyword', keyword);
+  if (sort) urlSearchParams.append('sort', sort);
 
   try {
     const res = await axiosInstance.get<ActivityResponse>(
@@ -31,17 +31,5 @@ const getCurrentPageActivity = async (
     return defaultActivityResponse;
   }
 };
-
-// export const getActivity = async (pageNum: number, size: number): Promise<ActivityResponse> => {
-//   try {
-//     const res = await axiosInstance.get<ActivityResponse>(
-//       `/activities?method=offset&page=${pageNum + 1}&size=${size}`
-//     );
-//     return res.data;
-//   } catch (e) {
-//     console.error('Error: ', e);
-//     return defaultActivityResponse;
-//   }
-// };
 
 export default getCurrentPageActivity;

--- a/src/api/getSearchResult.ts
+++ b/src/api/getSearchResult.ts
@@ -1,0 +1,32 @@
+import axiosInstance from '@/lib/axiosInstance';
+import { ActivityResponse } from '@/types/mainPage';
+
+const defaultActivityResponse: ActivityResponse = {
+  activities: [],
+  totalCount: 0,
+};
+
+const getSearchResult = async (
+  keyword: string,
+  pageNum: number,
+  size: number,
+): Promise<ActivityResponse> => {
+  const urlSearchParams = new URLSearchParams({
+    method: 'offset',
+    keyword,
+    page: String(pageNum + 1),
+    size: String(size),
+  });
+
+  try {
+    const res = await axiosInstance.get<ActivityResponse>(
+      `/activities?${urlSearchParams}`
+    );
+    return res.data;
+  } catch (e) {
+    console.error('Error: ', e);
+    return defaultActivityResponse;
+  }
+};
+
+export default getSearchResult;

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -1,36 +1,57 @@
 import Pagination from '@/components/mainpage/Pagination';
 import ActivityCard from '@/components/mainpage/ActivityCard';
-import { useEffect, useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 import { ActivityInfo } from '@/types/mainPage';
 import getCurrentPageActivity from '@/api/getCurrentPageActivity';
+import CategoryFilter from './CategoryFilter';
 
 const OFFSET_LIMIT = 8;
 
 const ActivityCardList = () => {
   const [currenData, setCurrentData] = useState<ActivityInfo[]>([]);
+  const [currentCategory, setCurrentCategory] = useState('');
+  const [sortActivity, setSortActivity] = useState('');
   const [count, setCount] = useState(1);
 
   // 페이지를 넘길 때마다 해당 페이지의 데이터를 불러오는 함수.
   const handlePageData = async (pageNum: number, size: number) => {
     try {
-      const { activities } = await getCurrentPageActivity(pageNum, size);
+      const { activities } = await getCurrentPageActivity(
+        pageNum, size, currentCategory, sortActivity);
       setCurrentData(activities);
     } catch (e) {
       console.error('Error: ', e);
     }
   };
 
+  const handleCategoryClick = (e: MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    if (currentCategory === button.value) return setCurrentCategory('');
+    return setCurrentCategory(button.value);
+  };
+
+  const handleSortClick = (e: MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    setSortActivity(button.value);
+  };
+
   useEffect(() => {
     const fetchPageData = async () => {
-      const data = await getCurrentPageActivity(1, OFFSET_LIMIT);
+      const data = await getCurrentPageActivity(0, OFFSET_LIMIT, currentCategory, sortActivity);
       setCurrentData(data.activities);
       setCount(data.totalCount);
     };
     fetchPageData();
-  }, []);
+  }, [currentCategory, sortActivity]);
 
-  return (
+  return count ? (
     <>
+      <CategoryFilter
+        currentCategory={currentCategory}
+        onSelectCategory={handleCategoryClick}
+        onSetSort={handleSortClick}
+      />
+      <div className="text-4xl font-bold mt-10 mb-[33px]">🛼 모든 체험</div>
       <div className="grid grid-cols-4 gap-6 mb-[72px]">
         {currenData.map((activity) => (
           <ActivityCard key={activity.id} cardData={activity} />
@@ -38,6 +59,8 @@ const ActivityCardList = () => {
       </div>
       <Pagination totalCount={count} offsetLimit={OFFSET_LIMIT} setActivityList={handlePageData} />
     </>
+  ) : (
+    <div>데이터가 없습니다.</div>
   );
 };
 

--- a/src/components/mainpage/ActivitySearch.tsx
+++ b/src/components/mainpage/ActivitySearch.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const ActivitySearch = () => {
@@ -12,6 +12,12 @@ const ActivitySearch = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     navigate(`/search?keyword=${searchWord}`);
+  };
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (searchWord === '') navigate('/');
+    else navigate(`/search?keyword=${searchWord}`);
   };
 
   return (
@@ -39,6 +45,7 @@ const ActivitySearch = () => {
           <button
             className="bg-nomad-black rounded-md w-[136px] h-14 px-10 py-2 text-white font-bold"
             type="submit"
+            onClick={handleClick}
           >
             검색하기
           </button>

--- a/src/components/mainpage/ActivitySearch.tsx
+++ b/src/components/mainpage/ActivitySearch.tsx
@@ -1,22 +1,32 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const ActivitySearch = () => {
   const [searchWord, setSearchWord] = useState('');
+  const navigate = useNavigate();
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchWord(e.target.value);
-    console.log(searchWord);
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    navigate(`/search?keyword=${searchWord}`);
   };
 
   return (
     <div className="relative bg-white pb-32">
-      <form className="absolute -top-14 flex flex-col gap-8 px-6 py-8 shadow-lg rounded-2xl bg-white">
+      <form
+        className="absolute -top-14 flex flex-col gap-8 px-6 py-8 shadow-lg rounded-2xl bg-white"
+        onSubmit={handleSubmit}
+      >
         <label className="text-black text-xl font-bold">무엇을 체험하고 싶으신가요?</label>
         <div className="flex items-center gap-3">
           <div className="relative">
             <input
               className="w-[62.5rem] h-14 border border-gray-60 border-solid rounded-md px-4 py-2 placeholder:pl-5 focus:outline-none focus:border-green-40"
               type="search"
+              value={searchWord}
               onChange={handleChange}
               placeholder="내가 원하는 체험은"
             />
@@ -27,8 +37,8 @@ const ActivitySearch = () => {
             />
           </div>
           <button
-            type="submit"
             className="bg-nomad-black rounded-md w-[136px] h-14 px-10 py-2 text-white font-bold"
+            type="submit"
           >
             검색하기
           </button>

--- a/src/components/mainpage/CategoryFilter.tsx
+++ b/src/components/mainpage/CategoryFilter.tsx
@@ -3,31 +3,30 @@ import FilterPopover from './FilterPopover';
 
 const CATEGORY_LIST = ['문화 · 예술', '식음료', '스포츠', '투어', '웰빙'];
 
-const CategoryFilter = () => {
+interface CategoryFilterProps {
+  currentCategory: string;
+  onSelectCategory: (e: MouseEvent<HTMLButtonElement>) => void;
+  onSetSort: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+const CategoryFilter = ({ currentCategory, onSelectCategory, onSetSort }: CategoryFilterProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [currentCategory, setCurrentCategory] = useState('');
 
   const handleFilterClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setIsOpen(!isOpen);
   };
 
-  const handleCategoryClick = (e: MouseEvent<HTMLButtonElement>) => {
-    const button = e.target as HTMLButtonElement;
-    setCurrentCategory(button.value);
-  };
-  console.log(currentCategory);
-
   return (
     <div className="flex justify-between text-green-80">
       <div className="flex gap-6">
         {CATEGORY_LIST.map((category) => (
           <button
-            className="w-[127px] text-lg border border-green-80 rounded-2xl px-5 py-4 hover:bg-green-80 hover:text-white"
+            className={`w-[127px] text-lg border border-green-80 rounded-2xl px-5 py-4 hover:bg-green-80 hover:text-white ${category === currentCategory && 'bg-green-80 text-white'}`}
             type="button"
             key={category}
             value={category}
-            onClick={handleCategoryClick}
+            onClick={onSelectCategory}
           >
             {category}
           </button>
@@ -42,7 +41,7 @@ const CategoryFilter = () => {
           가격
           <img src="/assets/arrow_down.svg" alt="dropdown" />
         </button>
-        <FilterPopover isOpen={isOpen} />
+        <FilterPopover isOpen={isOpen} onSetSort={onSetSort} />
       </div>
     </div>
   );

--- a/src/components/mainpage/FilterPopover.tsx
+++ b/src/components/mainpage/FilterPopover.tsx
@@ -1,26 +1,39 @@
-const POPOVER_VALUES = ['가격 낮은 순', '가격 높은 순'];
+import { MouseEvent } from 'react';
+
+const POPOVER_VALUES = [
+  { buttonName: '가격 낮은 순', sortKey: 'price_asc' },
+  { buttonName: '가격 높은 순', sortKey: 'price_desc' }
+];
+
 interface FilterPopoverProp {
   isOpen: boolean;
+  onSetSort: (e: MouseEvent<HTMLButtonElement>) => void;
 }
 
-const FilterPopover = ({ isOpen }: FilterPopoverProp) => (
-  <div
-    style={{ display: isOpen ? 'block' : 'none' }}
-    className="absolute top-[66px] flex flex-col text-green-80"
-  >
-    <button
-      className="w-[127px] bg-white border border-gray-30 rounded-t-xl py-4 hover:bg-green-10"
-      type="button"
+const FilterPopover = ({ isOpen, onSetSort }: FilterPopoverProp) => {
+  return (
+    <div
+      style={{ display: isOpen ? 'block' : 'none' }}
+      className="absolute top-[66px] flex flex-col text-green-80"
     >
-      {POPOVER_VALUES[0]}
-    </button>
-    <button
-      className="w-[127px] bg-white border border-gray-30 rounded-b-xl py-4 hover:bg-green-10"
-      type="button"
-    >
-      {POPOVER_VALUES[1]}
-    </button>
-  </div>
-);
+      <button
+        className="w-[127px] bg-white border border-gray-30 rounded-t-xl py-4 hover:bg-green-10"
+        type="button"
+        value={POPOVER_VALUES[0].sortKey}
+        onClick={onSetSort}
+      >
+        {POPOVER_VALUES[0].buttonName}
+      </button>
+      <button
+        className="w-[127px] bg-white border border-gray-30 rounded-b-xl py-4 hover:bg-green-10"
+        type="button"
+        value={POPOVER_VALUES[1].sortKey}
+        onClick={onSetSort}
+      >
+        {POPOVER_VALUES[1].buttonName}
+      </button>
+    </div>
+  );
+};
 
 export default FilterPopover;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,8 +1,7 @@
-import CategoryFilter from '@/components/mainpage/CategoryFilter';
-import ActivitySearch from '@/components/mainpage/ActivitySearch';
 import MainBanner from '@/components/mainpage/MainBanner';
-import ActivityCardList from '@/components/mainpage/ActivityCardList';
+import ActivitySearch from '@/components/mainpage/ActivitySearch';
 import PopularActivityList from '@/components/mainpage/PopularActivityList';
+import ActivityCardList from '@/components/mainpage/ActivityCardList';
 
 const MainPage = () => (
   <>
@@ -11,8 +10,6 @@ const MainPage = () => (
       <div className="w-pc mb-32">
         <ActivitySearch />
         <PopularActivityList />
-        <CategoryFilter />
-        <div className="text-4xl font-bold mt-10 mb-[33px]">🛼 모든 체험</div>
         <ActivityCardList />
       </div>
     </div>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -13,17 +13,16 @@ const SearchResultPage = () => {
   const [currenData, setCurrentData] = useState<ActivityInfo[]>([]);
   const [count, setCount] = useState(1);
   const [searchParams] = useSearchParams();
+  const keyword = searchParams.get('keyword');
 
   const handlePageActivity = async (pageNum: number, size: number) => {
-    const searchQuery = searchParams.get('keyword');
-    const { activities } = await getSearchResult(searchQuery as string, pageNum, size);
+    const { activities } = await getSearchResult(keyword as string, pageNum, size);
     setCurrentData(activities);
   };
 
   useEffect(() => {
     const fetchPageData = async () => {
-      const searchQuery = searchParams.get('keyword');
-      const data = await getSearchResult(searchQuery as string, 0, OFFSET_LIMIT);
+      const data = await getSearchResult(keyword as string, 0, OFFSET_LIMIT);
       setCurrentData(data.activities);
       setCount(data.totalCount);
     };
@@ -36,16 +35,22 @@ const SearchResultPage = () => {
       <div className="flex flex-col items-center">
         <div className="w-pc mb-32">
           <ActivitySearch />
-          <div className="grid grid-cols-4grid grid-cols-4 gap-6 mb-[72px]">
-            {currenData.map((activity) => (
-              <ActivityCard key={activity.id} cardData={activity} />
-            ))}
-          </div>
-          <Pagination
-            totalCount={count}
-            offsetLimit={OFFSET_LIMIT}
-            setActivityList={handlePageActivity}
-          />
+          {count ? (
+            <>
+              <div className="grid grid-cols-4grid grid-cols-4 gap-6 mb-[72px]">
+                {currenData.map((activity) => (
+                  <ActivityCard key={activity.id} cardData={activity} />
+                ))}
+              </div>
+              <Pagination
+                totalCount={count}
+                offsetLimit={OFFSET_LIMIT}
+                setActivityList={handlePageActivity}
+              />
+            </>
+          ) : (
+            <div>데이터가 없습니다.</div>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -35,6 +35,13 @@ const SearchResultPage = () => {
       <div className="flex flex-col items-center">
         <div className="w-pc mb-32">
           <ActivitySearch />
+          <div className="flex flex-col gap-3 text-nomad-black mt-10 mb-[60px]">
+            <div className="text-[2rem]">
+              <span className="font-bold">{keyword}</span>
+              으로 검색한 결과입니다.
+            </div>
+            <div>총 {count}개의 결과</div>
+          </div>
           {count ? (
             <>
               <div className="grid grid-cols-4grid grid-cols-4 gap-6 mb-[72px]">

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,0 +1,55 @@
+import getSearchResult from '@/api/getSearchResult';
+import ActivityCard from '@/components/mainpage/ActivityCard';
+import ActivitySearch from '@/components/mainpage/ActivitySearch';
+import MainBanner from '@/components/mainpage/MainBanner';
+import Pagination from '@/components/mainpage/Pagination';
+import { ActivityInfo } from '@/types/mainPage';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const OFFSET_LIMIT = 16;
+
+const SearchResultPage = () => {
+  const [currenData, setCurrentData] = useState<ActivityInfo[]>([]);
+  const [count, setCount] = useState(1);
+  const [searchParams] = useSearchParams();
+
+  const handlePageActivity = async (pageNum: number, size: number) => {
+    const searchQuery = searchParams.get('keyword');
+    const { activities } = await getSearchResult(searchQuery as string, pageNum, size);
+    setCurrentData(activities);
+  };
+
+  useEffect(() => {
+    const fetchPageData = async () => {
+      const searchQuery = searchParams.get('keyword');
+      const data = await getSearchResult(searchQuery as string, 0, OFFSET_LIMIT);
+      setCurrentData(data.activities);
+      setCount(data.totalCount);
+    };
+    fetchPageData();
+  }, [searchParams]);
+
+  return (
+    <div>
+      <MainBanner />
+      <div className="flex flex-col items-center">
+        <div className="w-pc mb-32">
+          <ActivitySearch />
+          <div className="grid grid-cols-4grid grid-cols-4 gap-6 mb-[72px]">
+            {currenData.map((activity) => (
+              <ActivityCard cardData={activity} />
+            ))}
+          </div>
+          <Pagination
+            totalCount={count}
+            offsetLimit={OFFSET_LIMIT}
+            setActivityList={handlePageActivity}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchResultPage;

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,11 +1,11 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { ActivityInfo } from '@/types/mainPage';
 import getSearchResult from '@/api/getSearchResult';
 import ActivityCard from '@/components/mainpage/ActivityCard';
 import ActivitySearch from '@/components/mainpage/ActivitySearch';
 import MainBanner from '@/components/mainpage/MainBanner';
 import Pagination from '@/components/mainpage/Pagination';
-import { ActivityInfo } from '@/types/mainPage';
-import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 const OFFSET_LIMIT = 16;
 
@@ -38,7 +38,7 @@ const SearchResultPage = () => {
           <ActivitySearch />
           <div className="grid grid-cols-4grid grid-cols-4 gap-6 mb-[72px]">
             {currenData.map((activity) => (
-              <ActivityCard cardData={activity} />
+              <ActivityCard key={activity.id} cardData={activity} />
             ))}
           </div>
           <Pagination


### PR DESCRIPTION
## 💻 작업 내용

- 카테고리 별로 필터링 되는 기능과 가격 높은/낮은 순으로 정렬되는 기능 구현
- 검색 시 이동할 경로와 검색 페이지 작성
- 검색 기능 구현 및 api 연결


## 🖼️ 스크린샷

![스크린샷 2024-06-03 022149](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/c12b6b5a-2f79-4d51-965f-fd54a1eac731)
![스크린샷 2024-06-03 022249](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/5d84fc75-17d0-4eda-9660-794ef15fc034)


## 🚨 관련 이슈 및 참고 사항

- UI 적인 부분에서 조금 미흡한 부분이 있습니다. 3주차에 리팩토링을 진행하며 UI 또한 완성할 예정입니다.
- 메인 페이지에서 검색어 입력 후 enter 키 및 버튼 클릭 시 '/search?keyword=검색어' 로 이동하도록 구현했습니다.
- 검색 페이지를 급하게 만드느라 컴포넌트 분리가 안되어 있는데, 이 또한 3주차에 리팩토링과 함께 분리 진행할 예정입니다.
