### PR TITLE
[GNTF-53] 예약 현황 페이지 체험 드롭다운, 달력 예약 상태 기능 구현

### DIFF
--- a/public/assets/chevron_down.svg
+++ b/public/assets/chevron_down.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="chevron_down">
+<path id="Vector" d="M5.25 9L12 15.75L18.75 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/api/getMyActivity.ts
+++ b/src/api/getMyActivity.ts
@@ -1,0 +1,13 @@
+import axiosInstance from '@/lib/axiosInstance';
+
+const getMyActivity = async (): Promise<any> => {
+  try {
+    const response = await axiosInstance.get('/my-activities');
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching My activity data:', error);
+    throw error;
+  }
+};
+
+export default getMyActivity;

--- a/src/api/getReservationYearAndMonth.ts
+++ b/src/api/getReservationYearAndMonth.ts
@@ -1,0 +1,17 @@
+import axiosInstance from '@/lib/axiosInstance';
+import { QueryFunctionContext } from '@tanstack/react-query';
+
+const getReservationYearAndMonth = async ({ queryKey }: QueryFunctionContext): Promise<any> => {
+  const [, activityId, year, month] = queryKey;
+  try {
+    const response = await axiosInstance.get(
+      `/my-activities/${activityId}/reservation-dashboard?year=${year}&month=${month}`,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching My activity data:', error);
+    throw error;
+  }
+};
+
+export default getReservationYearAndMonth;

--- a/src/components/reserveStatus/ActivityDropDownBox.tsx
+++ b/src/components/reserveStatus/ActivityDropDownBox.tsx
@@ -1,7 +1,31 @@
 import { useState } from 'react';
 import ActivityDrownDownList from './ActivityDropDownList';
 
-const ActivityDropDownBox = () => {
+interface Activity {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  rating: number;
+  reviewCount: number;
+  address: string;
+  bannerImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  userId: number;
+}
+
+interface ActivityDropDownBoxProps {
+  setSelectedActivity: React.Dispatch<React.SetStateAction<Activity | null>>;
+  activities?: Activity[];
+  selectedActivity: Activity | null;
+}
+const ActivityDropDownBox = ({
+  setSelectedActivity,
+  activities,
+  selectedActivity,
+}: ActivityDropDownBoxProps) => {
   const [viewDropDownList, setViewDropDownList] = useState(false);
 
   const toggleDropDown = () => {
@@ -9,8 +33,11 @@ const ActivityDropDownBox = () => {
   };
   return (
     <div className="relative">
-      <label className="absolute bg-white top-[-10px] left-4 text-[#121121] px-1">체험명</label>
-      <input className="rounded border border-gray-70 w-full pl-4 py-5 outline-none" />
+      <label className="absolute bg-white top-[-10px] left-4 text-[#121121] px-1">체험 목록</label>
+      <input
+        className="rounded border border-gray-70 w-full pl-4 py-5 outline-none"
+        value={selectedActivity?.title}
+      />
       <button type="button" onClick={toggleDropDown}>
         <img
           src="assets/chevron_down.svg"
@@ -18,7 +45,13 @@ const ActivityDropDownBox = () => {
           className="absolute w-6 top-5 right-3 cursor-pointer"
         />
       </button>
-      {viewDropDownList && <ActivityDrownDownList />}
+      {viewDropDownList && (
+        <ActivityDrownDownList
+          activities={activities}
+          setSelectedActivity={setSelectedActivity}
+          setViewDropDownList={setViewDropDownList}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/reserveStatus/ActivityDropDownBox.tsx
+++ b/src/components/reserveStatus/ActivityDropDownBox.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import ActivityDrownDownList from './ActivityDropDownList';
+
+const ActivityDropDownBox = () => {
+  const [viewDropDownList, setViewDropDownList] = useState(false);
+
+  const toggleDropDown = () => {
+    setViewDropDownList((prev) => !prev);
+  };
+  return (
+    <div className="relative">
+      <label className="absolute bg-white top-[-10px] left-4 text-[#121121] px-1">체험명</label>
+      <input className="rounded border border-gray-70 w-full pl-4 py-5 outline-none" />
+      <button type="button" onClick={toggleDropDown}>
+        <img
+          src="assets/chevron_down.svg"
+          alt="chevron-down-icon"
+          className="absolute w-6 top-5 right-3 cursor-pointer"
+        />
+      </button>
+      {viewDropDownList && <ActivityDrownDownList />}
+    </div>
+  );
+};
+
+export default ActivityDropDownBox;

--- a/src/components/reserveStatus/ActivityDropDownList.tsx
+++ b/src/components/reserveStatus/ActivityDropDownList.tsx
@@ -1,16 +1,40 @@
 import ActivityDropDownListItem from './ActivityDropDownListItem';
 
-const ActivityDrownDownList = () => (
+interface Activity {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  rating: number;
+  reviewCount: number;
+  address: string;
+  bannerImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  userId: number;
+}
+interface ActivityDropDownListProps {
+  activities?: Activity[];
+  setSelectedActivity: React.Dispatch<React.SetStateAction<Activity | null>>;
+  setViewDropDownList: React.Dispatch<React.SetStateAction<boolean>>;
+}
+const ActivityDrownDownList = ({
+  activities,
+  setSelectedActivity,
+  setViewDropDownList,
+}: ActivityDropDownListProps) => (
   <ul className="flex flex-col bg-white rounded absolute w-full top-[80px] border border-gray-70 h-[400px] overflow-y-auto">
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
-    <ActivityDropDownListItem />
+    {activities?.map((activity) => {
+      return (
+        <ActivityDropDownListItem
+          title={activity.title}
+          setSelectedActivity={setSelectedActivity}
+          activity={activity}
+          setViewDropDownList={setViewDropDownList}
+        />
+      );
+    })}
   </ul>
 );
 

--- a/src/components/reserveStatus/ActivityDropDownList.tsx
+++ b/src/components/reserveStatus/ActivityDropDownList.tsx
@@ -1,11 +1,16 @@
+import ActivityDropDownListItem from './ActivityDropDownListItem';
+
 const ActivityDrownDownList = () => (
-  <ul className="bg-red-400">
-    <li>체험1</li>
-    <li>체험2</li>
-    <li>체험3</li>
-    <li>체험4</li>
-    <li>체험5</li>
-    <li>체험6</li>
+  <ul className="flex flex-col bg-white rounded absolute w-full top-[80px] border border-gray-70 h-[400px] overflow-y-auto">
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
+    <ActivityDropDownListItem />
   </ul>
 );
 

--- a/src/components/reserveStatus/ActivityDropDownList.tsx
+++ b/src/components/reserveStatus/ActivityDropDownList.tsx
@@ -1,0 +1,12 @@
+const ActivityDrownDownList = () => (
+  <ul className="bg-red-400">
+    <li>체험1</li>
+    <li>체험2</li>
+    <li>체험3</li>
+    <li>체험4</li>
+    <li>체험5</li>
+    <li>체험6</li>
+  </ul>
+);
+
+export default ActivityDrownDownList;

--- a/src/components/reserveStatus/ActivityDropDownListItem.tsx
+++ b/src/components/reserveStatus/ActivityDropDownListItem.tsx
@@ -1,0 +1,5 @@
+const ActivityDropDownListItem = () => (
+  <li className="px-5 py-5 border-b border-gray-70 last:border-b-0">체험1</li>
+);
+
+export default ActivityDropDownListItem;

--- a/src/components/reserveStatus/ActivityDropDownListItem.tsx
+++ b/src/components/reserveStatus/ActivityDropDownListItem.tsx
@@ -1,5 +1,43 @@
-const ActivityDropDownListItem = () => (
-  <li className="px-5 py-5 border-b border-gray-70 last:border-b-0">체험1</li>
-);
+interface Activity {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  rating: number;
+  reviewCount: number;
+  address: string;
+  bannerImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  userId: number;
+}
+
+interface ActivityDropDownListItemProps {
+  activity: Activity;
+  setSelectedActivity: React.Dispatch<React.SetStateAction<Activity | null>>;
+  title: string;
+  setViewDropDownList: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ActivityDropDownListItem = ({
+  activity,
+  setSelectedActivity,
+  title,
+  setViewDropDownList,
+}: ActivityDropDownListItemProps) => {
+  const onClickListItem = () => {
+    setViewDropDownList((prev) => !prev);
+    setSelectedActivity(activity);
+  };
+  return (
+    <li
+      className="px-5 py-5 border-b border-gray-70 last:border-b-0 hover:bg-sky-200 cursor-pointer"
+      onClick={onClickListItem}
+    >
+      {title}
+    </li>
+  );
+};
 
 export default ActivityDropDownListItem;

--- a/src/components/reserveStatus/ComfirmedTileBlock.tsx
+++ b/src/components/reserveStatus/ComfirmedTileBlock.tsx
@@ -1,0 +1,5 @@
+const ComfimedTileBlock = ({ count }: { count: number }) => (
+  <div className="w-full bg-[#FFF4E8] px-[3px] py-[4px] rounded text-[#FF7C1D]">승인 {count}</div>
+);
+
+export default ComfimedTileBlock;

--- a/src/components/reserveStatus/CompletedTileBlock.tsx
+++ b/src/components/reserveStatus/CompletedTileBlock.tsx
@@ -1,0 +1,5 @@
+const CompletedTileBlock = ({ count }: { count: number }) => (
+  <div className="w-full bg-[#DDD] px-[3px] py-[4px] rounded text-[#4B4B4B]">완료 {count}</div>
+);
+
+export default CompletedTileBlock;

--- a/src/components/reserveStatus/PendingTileBlock.tsx
+++ b/src/components/reserveStatus/PendingTileBlock.tsx
@@ -1,0 +1,5 @@
+const PendingTileBlock = ({ count }: { count: number }) => (
+  <div className="w-full bg-[#0085FF] px-[3px] py-[4px] rounded text-white">대기 {count}</div>
+);
+
+export default PendingTileBlock;

--- a/src/components/reserveStatus/ReserveStatusContent.tsx
+++ b/src/components/reserveStatus/ReserveStatusContent.tsx
@@ -1,0 +1,12 @@
+import ActivityDropDownBox from './ActivityDropDownBox';
+
+const ReserveStatusContent = () => (
+  <div className="w-[800px]">
+    <div className="flex flex-col gap-8">
+      <div className="text-[32px] font-bold">예약 현황</div>
+      <ActivityDropDownBox />
+    </div>
+  </div>
+);
+
+export default ReserveStatusContent;

--- a/src/components/reserveStatus/ReserveStatusContent.tsx
+++ b/src/components/reserveStatus/ReserveStatusContent.tsx
@@ -1,12 +1,153 @@
+import { useQuery } from '@tanstack/react-query';
+import getMyActivity from '@/api/getMyActivity';
+import React, { useEffect, useState } from 'react';
+import getReservationYearAndMonth from '@/api/getReservationYearAndMonth';
+import Calendar from 'react-calendar';
+import moment from 'moment';
 import ActivityDropDownBox from './ActivityDropDownBox';
+import 'react-calendar/dist/Calendar.css';
+import PendingTileBlock from './PendingTileBlock';
+import CompletedTileBlock from './CompletedTileBlock';
+import ComfimedTileBlock from './ComfirmedTileBlock';
 
-const ReserveStatusContent = () => (
-  <div className="w-[800px]">
-    <div className="flex flex-col gap-8">
-      <div className="text-[32px] font-bold">예약 현황</div>
-      <ActivityDropDownBox />
+interface ReservationType {
+  date: string;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
+}
+
+interface Activity {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  rating: number;
+  reviewCount: number;
+  address: string;
+  bannerImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+  userId: number;
+}
+
+interface ActivityData {
+  activities: Activity[];
+}
+
+interface MonthInfo {
+  year: string;
+  month: string;
+}
+
+const ReserveStatusContent = () => {
+  const [selectedActivity, setSelectedActivity] = useState<Activity | null>(null);
+  const [activeMonth, setActiveMonth] = useState<MonthInfo>({
+    year: moment().format('YYYY'),
+    month: moment().format('MM'),
+  });
+  const { data, isLoading, error } = useQuery<ActivityData>({
+    queryKey: ['myActivity'],
+    queryFn: getMyActivity,
+  });
+
+  const { data: reservationData } = useQuery({
+    queryKey: ['reservationTimeTable', selectedActivity?.id, activeMonth.year, activeMonth.month],
+    queryFn: getReservationYearAndMonth,
+  });
+
+  const getActiveMonth = (activeStartDate: Date) => {
+    const activeYearMonth = {
+      year: moment(activeStartDate).format('YYYY'),
+      month: moment(activeStartDate).format('MM'),
+    };
+    console.log('Active Year-Month:', activeYearMonth);
+    setActiveMonth(activeYearMonth);
+  };
+
+  useEffect(() => {
+    if (data && data.activities && data.activities.length > 0) {
+      setSelectedActivity(data.activities[0]);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    const currentDate = new Date();
+    const initialYearMonth = {
+      year: moment(currentDate).format('YYYY'),
+      month: moment(currentDate).format('MM'),
+    };
+    setActiveMonth(initialYearMonth);
+    console.log('Initial Year-Month:', initialYearMonth);
+  }, []);
+
+  if (isLoading) {
+    return <div>데이터 불러오는중</div>;
+  }
+
+  if (error) {
+    return <div>Error loading data</div>;
+  }
+
+  console.log(reservationData);
+  // 타일의 내용을 커스터마이즈하는 함수
+  const tileContent = ({ date }: { date: Date }) => {
+    // 일치하는 날짜가 없는 경우 빈 문자열 반환
+    if (!reservationData) return '';
+
+    // 예약 데이터에서 해당 날짜의 정보 가져오기
+    const matchedReservation = reservationData.find(
+      (item: ReservationType) => item.date === moment(date).format('YYYY-MM-DD'),
+    );
+
+    // 해당 날짜에 예약 정보가 있는 경우 각 상태의 개수를 표시
+    if (matchedReservation) {
+      const { completed, confirmed, pending } = matchedReservation.reservations;
+      return (
+        <div>
+          {pending !== 0 && <PendingTileBlock count={pending} />}
+          <br />
+          {completed !== 0 && <CompletedTileBlock count={completed} />}
+          <br />
+          {confirmed !== 0 && <ComfimedTileBlock count={confirmed} />}
+          <br />
+        </div>
+      );
+    }
+
+    return ''; // 예약 정보가 없는 경우 빈 문자열 반환
+  };
+
+  return (
+    <div className="w-[800px]">
+      <div className="flex flex-col gap-8">
+        <div className="text-[32px] font-bold">예약 현황</div>
+        <ActivityDropDownBox
+          setSelectedActivity={setSelectedActivity}
+          activities={data?.activities}
+          selectedActivity={selectedActivity}
+        />
+      </div>
+      {selectedActivity && <div>{selectedActivity.title}</div>}
+      <Calendar
+        className="w-full p-0"
+        locale="ko"
+        formatShortWeekday={(locale, date) =>
+          ['일', '월', '화', '수', '목', '금', '토'][date.getDay()]}
+        formatDay={(locale, date) => moment(date).format('DD')}
+        calendarType="hebrew"
+        onActiveStartDateChange={(datas) => {
+          if (datas.activeStartDate) {
+            getActiveMonth(datas.activeStartDate);
+          }
+        }}
+        tileContent={tileContent}
+      />
     </div>
-  </div>
-);
+  );
+};
 
 export default ReserveStatusContent;

--- a/src/components/reserveStatus/ReserveStatysContent.tsx
+++ b/src/components/reserveStatus/ReserveStatysContent.tsx
@@ -1,0 +1,3 @@
+const ReserveStatusContent = () => <div className="w-[800px]">예약 현황</div>;
+
+export default ReserveStatusContent;

--- a/src/components/reserveStatus/ReserveStatysContent.tsx
+++ b/src/components/reserveStatus/ReserveStatysContent.tsx
@@ -1,3 +1,0 @@
-const ReserveStatusContent = () => <div className="w-[800px]">예약 현황</div>;
-
-export default ReserveStatusContent;

--- a/src/pages/ReservationsPage.tsx
+++ b/src/pages/ReservationsPage.tsx
@@ -27,9 +27,7 @@ const ReservationsPage = () => {
   });
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedBooking, setSelectedBooking] = useState<BookingData | null>(
-    null,
-  );
+  const [selectedBooking, setSelectedBooking] = useState<BookingData | null>(null);
 
   /* 후기 작성 버튼에 연결되도록 해야 함 */
 
@@ -59,11 +57,7 @@ const ReservationsPage = () => {
       <Profile />
       <ReservationContent status={status} setStatus={setStatus} />
       <ModalPortal>
-        <ReviewModal
-          isOpen={isModalOpen}
-          onClose={handleModalClose}
-          booking={selectedBooking}
-        />
+        <ReviewModal isOpen={isModalOpen} onClose={handleModalClose} booking={selectedBooking} />
       </ModalPortal>
     </div>
   );

--- a/src/pages/ReserveStatusPage.tsx
+++ b/src/pages/ReserveStatusPage.tsx
@@ -1,5 +1,5 @@
 import Profile from '@/components/common/profile/Profile';
-import ReserveStatusContent from '@/components/reserveStatus/ReserveStatysContent';
+import ReserveStatusContent from '@/components/reserveStatus/ReserveStatusContent';
 import React from 'react';
 
 const ReserveStatusPage = () => (

--- a/src/pages/ReserveStatusPage.tsx
+++ b/src/pages/ReserveStatusPage.tsx
@@ -1,9 +1,11 @@
 import Profile from '@/components/common/profile/Profile';
+import ReserveStatusContent from '@/components/reserveStatus/ReserveStatysContent';
 import React from 'react';
 
 const ReserveStatusPage = () => (
-  <div>
+  <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[65px]">
     <Profile />
+    <ReserveStatusContent />
   </div>
 );
 

--- a/src/styles/tailwind-calendar.css
+++ b/src/styles/tailwind-calendar.css
@@ -53,6 +53,8 @@
 /* 달력 타일 */
 .react-calendar__tile {
   border-radius: 8px;
+  width: 100px;
+  height: 154px;
 }
 
 /* 호버 및 액티브 스타일 */
@@ -66,4 +68,12 @@
 .react-calendar__tile--now {
   background-color: #ced8d5;
   color: #0b3b2d;
+}
+
+.hidden-date {
+  visibility: hidden;
+}
+
+.custom-tile {
+  border: 1px solid black;
 }


### PR DESCRIPTION
## 💻 작업 내용


- 드롭다운으로 내가 등록한 체험 데이터를 불러옵니다
- 달력에 일치하는 스케쥴을 대기 ,승인 , 완료 형태로 표시합니다  
- tanstackquery를 이용해서 나의 체험, 내 체험 월별 예약 현황 조회 데이터 패칭

## 🖼️ 스크린샷

![Global Nomad - Chrome 2024-06-03 17-59-23](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/5d153d69-8b20-46d0-9a26-62fbf73d1baf)
내가 등록한 체험을 드롭다운으로 선택가능합니다 

![Global Nomad - Chrome 2024-06-03 17-59-43](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/1a6cf1a2-f8c2-450b-ab8c-f9353787674f)
체험을 선택하면 나의 스케쥴 날짜와 일치하는 달력의 타일에 상태들이 표시됩니다 

## 🚨 관련 이슈 및 참고 사항

- 달력 세부 디자인은 좀더 해야할꺼같습니다!
-  날짜 클릭시 예약 관리 모달 기능 추가예정입니다
