### PR TITLE
[GNTF-55] MyActivityPage에 삭제하기&NoReservation 연결, 최신순/무한스크롤 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-calendar": "^5.0.0",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.3.1",
+        "react-infinite-scroll-component": "^6.1.0",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "zustand": "^4.5.2"
@@ -15994,6 +15995,17 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "dependencies": {
+        "throttle-debounce": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/react-intersection-observer": {
       "version": "9.10.2",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.10.2.tgz",
@@ -18246,6 +18258,14 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ=="
+    },
+    "node_modules/throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/thunky": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-calendar": "^5.0.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "zustand": "^4.5.2"

--- a/public/assets/footer_icon_check.svg
+++ b/public/assets/footer_icon_check.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="#112211"/>
+<path d="M7.60693 12.3491L10.6873 15.5L16.2498 8.35718" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/myActivity/ExperienceDeleteModal.tsx
+++ b/src/components/myActivity/ExperienceDeleteModal.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useRef } from 'react';
+import axios from '@/lib/axiosInstance';
+import ModalBackground from '../review/ModalBackground';
+
+interface ExperienceDeleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activityId: number;
+  onDelete: () => void;
+}
+
+const ExperienceDeleteModal: React.FC<ExperienceDeleteModalProps> = ({
+  isOpen,
+  onClose,
+  activityId,
+  onDelete,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleOutsideClick);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [isOpen, onClose]);
+
+  const handleDeleteClick = async () => {
+    try {
+      await axios.delete(`/my-activities/${activityId}`);
+      onClose();
+      onDelete();
+    } catch (error) {
+      console.error('삭제 실패:', error);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const handleClick = (event: any) => event.stopPropagation();
+
+  return (
+    <ModalBackground onClose={onClose}>
+      <div
+        className="w-full h-full mob:w-[18.625rem] mob:h-[11.5rem] mob:rounded-xl bg-white p-6"
+        ref={modalRef}
+        onClick={handleClick}
+      >
+        <div className="w-full h-full flex flex-col items-center gap-8">
+          <div className="w-full flex flex-col items-center gap-4">
+            <img src="/assets/footer_icon_check.svg" alt="checkcBtn" />
+            <p className="leading-[1.625rem]">삭제하시겠습니까?</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="w-20 h-[2.375rem] flex justify-center items-center gap-2 py-[0.625rem] border border-[#121] rounded-md text-[0.875rem]"
+              onClick={onClose}
+            >
+              아니오
+            </button>
+            <button
+              type="button"
+              className="w-20 h-[2.375rem] flex justify-center items-center gap-2 py-[0.625rem] rounded-md bg-[#121] text-white text-[0.875rem]"
+              onClick={handleDeleteClick}
+            >
+              예
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalBackground>
+  );
+};
+
+export default ExperienceDeleteModal;

--- a/src/components/myActivity/ReservationCard.tsx
+++ b/src/components/myActivity/ReservationCard.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import priceToWon from '@/utils/priceToWon';
 import CustomKebabMenu from './CustomKebabMenu';
+import ExperienceDeleteModal from './ExperienceDeleteModal';
+import ModalPortal from '../review/ModalPortal';
 
 export interface Activity {
   id: number;
@@ -18,8 +21,24 @@ export interface Activity {
   updatedAt: string;
 }
 
-const ReservationCard = ({ activity }: { activity: Activity }) => {
+const ReservationCard = ({
+  activity,
+  onDelete,
+}: {
+  activity: Activity;
+  onDelete: (id: number) => void;
+}) => {
   const navigate = useNavigate();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const handleDeleteClick = () => {
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    onDelete(activity.id);
+    setIsDeleteModalOpen(false);
+  };
 
   return (
     <li className="rounded-3xl flex w-full h-[12.75rem] md:h-[9.75rem] sm:h-32 sm:min-w-[21.5rem] shadow-md">
@@ -57,11 +76,19 @@ const ReservationCard = ({ activity }: { activity: Activity }) => {
                     state: { ...activity },
                   }),
               },
-              { label: '삭제하기', onClick: () => console.log('안녕') },
+              { label: '삭제하기', onClick: handleDeleteClick },
             ]}
           />
         </div>
       </div>
+      <ModalPortal>
+        <ExperienceDeleteModal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          activityId={activity.id}
+          onDelete={handleDeleteConfirm}
+        />
+      </ModalPortal>
     </li>
   );
 };

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -3,6 +3,7 @@ import ReservationCard, { Activity } from '@/components/myActivity/ReservationCa
 import { useEffect, useState } from 'react';
 import axiosInstance from '@/lib/axiosInstance';
 import { useNavigate } from 'react-router-dom';
+import NoReservation from '@/components/myreservation/NoReservation';
 
 interface ApiResponse {
   cursorId: number;
@@ -54,15 +55,19 @@ const MyActivityPage = () => {
           </div>
           {/* 체험 리스트 */}
           <section className="w-full">
-            <ul className="flex flex-col gap-6">
-              {activities.map((activity) => (
-                <ReservationCard
-                  key={activity.id}
-                  activity={activity}
-                  onDelete={handleDeleteActivity}
-                />
-              ))}
-            </ul>
+            {activities.length !== 0 ? (
+              <ul className="flex flex-col gap-6">
+                {activities.map((activity) => (
+                  <ReservationCard
+                    key={activity.id}
+                    activity={activity}
+                    onDelete={handleDeleteActivity}
+                  />
+                ))}
+              </ul>
+            ) : (
+              <NoReservation />
+            )}
           </section>
         </div>
       </div>

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -31,6 +31,11 @@ const MyActivityPage = () => {
     navigate('/my-activity/assign');
   };
 
+  const handleDeleteActivity = (id: number) => {
+    const updatedActivities = activities.filter((activity) => activity.id !== id);
+    setActivities(updatedActivities);
+  };
+
   return (
     <section className=" bg-gray-10 px-4 py-16">
       <div className="flex max-w-[75rem] mx-auto gap-6 items-start">
@@ -51,7 +56,11 @@ const MyActivityPage = () => {
           <section className="w-full">
             <ul className="flex flex-col gap-6">
               {activities.map((activity) => (
-                <ReservationCard key={activity.id} activity={activity} />
+                <ReservationCard
+                  key={activity.id}
+                  activity={activity}
+                  onDelete={handleDeleteActivity}
+                />
               ))}
             </ul>
           </section>


### PR DESCRIPTION
## 💻 작업 내용
- MyActivityPage의 '삭제하시겠습니까?' 모달창 생성
- MyActivityPage에서 '삭제하기' 케밥버튼에 '삭제하시겠습니까?' 모달창 연결
- '삭제하시겠습니까?'에서 '예'를 누르면 체험삭제 api 연결
- MyActivityPage에서 등록한 체험이 없는 경우 'NoReservation' 컴포넌트 연결
- 'react-infinite-scroll-component'를 활용해 MyActivityPage 최신순/무한스크롤 추가

## 🖼️ 스크린샷
### 삭제하기 케밥
<img width="1080" alt="스크린샷 2024-06-04 오후 2 56 41" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/dff37341-6753-4aca-8dbd-7fd117c34350">

### 삭제하기 모달창
<img width="1081" alt="스크린샷 2024-06-04 오후 2 56 48" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/2ea8296e-0725-4cdf-bac4-3d40ec7a9ffc">

### 체험 삭제 후 MyActivityPage
<img width="1079" alt="스크린샷 2024-06-04 오후 2 57 00" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/566a5627-ea5d-4960-bf6f-4972f5832dd4">

## 🚨 관련 이슈 및 참고 사항
- 코드 정리 필요 (무한스크롤 endMessage 등)
- 무한스크롤 Loading 중일 때 현재 입력된 'Loading...'만 보일지, 로딩 인디케이터 사용할지 ?