### PR TITLE
[GNTF-72] 모든 체험 부분 페이지 이동 및 카테고리, 정렬 버튼 클릭 시 쿼리 스트링 추가

### DIFF
--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -30,7 +30,7 @@ const ActivityCardList = () => {
   const [currentCategory, setCurrentCategory] = useState('');
   const [sortActivity, setSortActivity] = useState('');
   const [offset, setOffset] = useState(calculateOffsetLimit());
-const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -92,8 +92,13 @@ const [searchParams, setSearchParams] = useSearchParams();
 
   const handleCategoryClick = (e: MouseEvent<HTMLButtonElement>) => {
     const button = e.target as HTMLButtonElement;
-    if (currentCategory === button.value) setCurrentCategory('');
-    else setCurrentCategory(button.value);
+    if (currentCategory === button.value) {
+      setCurrentCategory('');
+      searchParams.delete('category');
+    } else {
+      setCurrentCategory(button.value);
+      searchParams.set('category', button.value);
+    }
     setCurrentPageNum(0);
     setCurrentPageGroup(0);
   };
@@ -101,6 +106,7 @@ const [searchParams, setSearchParams] = useSearchParams();
   const handleSortClick = (e: MouseEvent<HTMLButtonElement>) => {
     const button = e.target as HTMLButtonElement;
     setSortActivity(button.value);
+    searchParams.set('sort', button.value);
     setCurrentPageNum(0);
     setCurrentPageGroup(0);
   };

--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useEffect, useState } from 'react';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import Pagination from '@/components/mainpage/Pagination';
 import ActivityCard from '@/components/mainpage/ActivityCard';
 import getCurrentPageActivity from '@/api/getCurrentPageActivity';
@@ -29,6 +30,8 @@ const ActivityCardList = () => {
   const [currentCategory, setCurrentCategory] = useState('');
   const [sortActivity, setSortActivity] = useState('');
   const [offset, setOffset] = useState(calculateOffsetLimit());
+const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handleResize = () => {
@@ -39,7 +42,30 @@ const ActivityCardList = () => {
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  });
+  }, []);
+
+  useEffect(() => {
+    const categoryParam = searchParams.get('category');
+    const sortParam = searchParams.get('sort');
+
+    if (categoryParam) searchParams.set('category', currentCategory);
+    if (sortParam) searchParams.set('sort', sortActivity);
+    searchParams.set('page', String(currentPageNum + 1));
+
+    navigate(`?${searchParams}`);
+  }, [currentCategory, sortActivity, currentPageNum, setSearchParams, navigate]);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      navigate('');
+    };
+
+    window.addEventListener('pageshow', handlePopState);
+
+    return () => {
+      window.removeEventListener('pageshow', handlePopState);
+    };
+  }, [navigate]);
 
   const { data: allActivityList, isLoading, isError } = usePageActivity(
     currentPageNum,


### PR DESCRIPTION
## 💻 작업 내용

- 모든 체험 부분에서 페이지를 이동하거나 카테고리, 정렬 버튼 클릭 시 해당 쿼리 스트링이 주소창에 나타나도록 구현했습니다.
- 카테고리는 선택 후 제거할 수 있으므로 쿼리 스트링에서도 카테고리 선택 제거 시 쿼리 또한 제거하도록 했습니다.

## 🖼️ 스크린샷

![스크린샷 2024-06-11 102204](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/ead0c2d7-1e77-4f3e-b3a1-6d6a81dc0049)
![스크린샷 2024-06-11 102212](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/997321a8-271a-4803-ad0b-c42a4a5169d7)
![스크린샷 2024-06-11 102232](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/a5f2054a-8489-4931-948d-72fed5f59495)
![스크린샷 2024-06-11 102242](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/ed2e4c87-d7ae-4f2b-b4a0-3af3d0c57f23)


## 🚨 관련 이슈 및 참고 사항

- 아직 주소창에서 쿼리 스트링 조작 시 이동이 안됩니다. 이번 멘토링 이후 개선해 볼 예정입니다.
