### PR TITLE
[GNTF-78] MyActivityPage - myProfile 공통 레이아웃 변경에 따른 반응형 CSS 수정

### DIFF
--- a/src/components/myActivity/CustomKebabMenu.tsx
+++ b/src/components/myActivity/CustomKebabMenu.tsx
@@ -31,7 +31,13 @@ const CustomKebabMenu = ({ options }: IProps) => {
   return (
     <div className="relative" ref={dropdownRef}>
       {/* 드롭다운 선택 영역 */}
-      <div role="button" tabIndex={0} onClick={toggleDropdown} onKeyDown={handleKeyDown}>
+      <div
+        className="sm:w-8 sm:h-8"
+        role="button"
+        tabIndex={0}
+        onClick={toggleDropdown}
+        onKeyDown={handleKeyDown}
+      >
         <img src="/assets/kebab_icon.svg" alt="kebabIcon" />
       </div>
       {/* 옵션 리스트 */}

--- a/src/components/myActivity/ReservationCard.tsx
+++ b/src/components/myActivity/ReservationCard.tsx
@@ -49,7 +49,7 @@ const ReservationCard = ({
           alt={activity.title}
         />
       </div>
-      <div className="p-5 md:p-3 flex justify-between flex-col gap-4 flex-grow">
+      <div className="p-5 md:p-3 sm:p-3 flex justify-between flex-col gap-4 flex-grow">
         <div>
           <p className="mb-[0.375rem] sm:mb-0 font-bold flex items-center gap-2">
             <span className="w-5 h-5 inline-flex justify-center items-center sm:w-[1rem] sm:h-[1rem]">

--- a/src/pages/MyActivityPage.tsx
+++ b/src/pages/MyActivityPage.tsx
@@ -44,45 +44,41 @@ const MyActivityPage = () => {
     );
   }
   return (
-    <section className=" bg-gray-10 px-4 py-16">
-      <div className="flex max-w-[75rem] mx-auto gap-6 items-start">
-        {/* 내 체험 관리 헤더 */}
-        <div className="w-full">
-          <div className="min-w-[21.5rem] flex justify-between mb-6">
-            <h2 className=" text-black font-bold text-[32px] self-start">내 체험 관리</h2>
-            <button
-              type="button"
-              className="flex min-w-[7.5rem] h-12 p-2.5 justify-center items-center gap-1 self-stretch rounded bg-[#121] text-white"
-              onClick={handleAssignClick}
-            >
-              체험 등록하기
-            </button>
-          </div>
-          {/* 체험 리스트 */}
-          <section className="w-full">
-            {activities.length !== 0 ? (
-              <>
-                <ul className="flex flex-col gap-6">
-                  {activities.map((activity) => (
-                    <ReservationCard
-                      key={activity.id}
-                      activity={activity}
-                      onDelete={() => handleDeleteActivity(activity.id)}
-                    />
-                  ))}
-                </ul>
-                {isFetchingNextPage && (
-                  <div className="flex justify-center items-center">
-                    <img src="/assets/spinner.svg" alt="loding_spinner" />
-                  </div>
-                )}
-              </>
-            ) : (
-              <NoReservation />
+    <section className="flex flex-col w-full max-w-[50rem] items-start">
+      {/* 내 체험 관리 헤더 */}
+      <div className="w-full min-w-[21.5rem] flex justify-between mb-6">
+        <h2 className=" text-black font-bold text-[32px] self-start">내 체험 관리</h2>
+        <button
+          type="button"
+          className="flex min-w-[7.5rem] h-12 p-2.5 justify-center items-center gap-1 self-stretch rounded bg-[#121] text-white"
+          onClick={handleAssignClick}
+        >
+          체험 등록하기
+        </button>
+      </div>
+      {/* 체험 리스트 */}
+      <div className="w-full">
+        {activities.length !== 0 ? (
+          <>
+            <ul className="flex flex-col gap-6">
+              {activities.map((activity) => (
+                <ReservationCard
+                  key={activity.id}
+                  activity={activity}
+                  onDelete={() => handleDeleteActivity(activity.id)}
+                />
+              ))}
+            </ul>
+            {isFetchingNextPage && (
+              <div className="flex justify-center items-center">
+                <img src="/assets/spinner.svg" alt="loding_spinner" />
+              </div>
             )}
-            <div ref={ref} className="h-[10px]" />
-          </section>
-        </div>
+          </>
+        ) : (
+          <NoReservation />
+        )}
+        <div ref={ref} className="h-[1.5rem]" />
       </div>
     </section>
   );


### PR DESCRIPTION
## 💻 작업 내용
- MyActivityPage - myProfile 공통 레이아웃 변경에 따른 반응형 CSS 수정

## 🖼️ 스크린샷
### pc 사이즈
<img width="1189" alt="스크린샷 2024-06-12 오후 2 52 14" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/254bc2ce-2926-41ec-8f20-9abe7da6d7d7">

### tablet 사이즈
<img width="762" alt="스크린샷 2024-06-12 오후 2 53 16" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/62f079a4-b239-4a17-96c9-41072923353a">

### mobile 사이즈
<img width="498" alt="스크린샷 2024-06-12 오후 2 53 30" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/8c5205cf-0045-44cb-8520-8c245eb2dab8">


## 🚨 관련 이슈 및 참고 사항
-
