### PR TITLE
[GNTF-88] 회원가입 페이지 리팩터링

### DIFF
--- a/src/api/handleLogin.ts
+++ b/src/api/handleLogin.ts
@@ -20,7 +20,7 @@ export interface LoginDataResponse {
 
 const handleLogin = async ({ email, password }: HandleLoginParams): Promise<LoginDataResponse> => {
   try {
-    const response = await axiosInstance.post('/auth/login', {
+    const response = await axiosInstance.post<LoginDataResponse>('/auth/login', {
       email,
       password,
     });

--- a/src/api/handleSignup.ts
+++ b/src/api/handleSignup.ts
@@ -1,36 +1,26 @@
 import axiosInstance from '@/lib/axiosInstance';
-
-export interface HandleSignupType {
-  email: string;
-  nickname: string;
-  password: string;
-}
-
-class SignupError extends Error {
-  status: number;
-
-  constructor(status: number) {
-    super('Signup Error');
-    this.status = status;
-    this.name = 'SignupError';
-  }
-}
+import { HandleSignupParams, UserProfile } from '@/types/signupPage';
 
 const handleSignup = async ({
   email,
   nickname,
   password,
-}: HandleSignupType): Promise<any> => {
-  const response = await axiosInstance.post('/users', {
-    email,
-    nickname,
-    password,
-  });
+}: HandleSignupParams): Promise<UserProfile> => {
+  try {
+    const response = await axiosInstance.post<UserProfile>('/users', {
+      email,
+      nickname,
+      password,
+    });
 
-  if (response.status !== 201) {
-    throw new SignupError(response.status);
+    if (response.status !== 201) {
+      throw new Error(`Signup Error ${response.status}`);
+    }
+    return response.data;
+  } catch (error) {
+    console.error('Login Error', error);
+    throw error;
   }
-  return response;
 };
 
 export default handleSignup;

--- a/src/components/common/auth/AuthButton.tsx
+++ b/src/components/common/auth/AuthButton.tsx
@@ -5,6 +5,7 @@ interface AuthButtonProps {
 const AuthButton = ({ children, disabled = false }: AuthButtonProps) => (
   <button
     type="submit"
+    disabled={disabled}
     className={`py-4 px-8 rounded-[6px] text-white text-lg font-semibold transition-opacity ${
       disabled ? 'bg-gray-400' : 'bg-blue-500 hover:opacity-90'
     }`}

--- a/src/components/common/auth/AuthLabel.tsx
+++ b/src/components/common/auth/AuthLabel.tsx
@@ -1,12 +1,10 @@
 interface AuthLabelProps {
   labelName: string;
+  inputName: string;
 }
 
-const AuthLabel = ({ labelName }: AuthLabelProps) => (
-  <label
-    htmlFor="email"
-    className="font-['Pretendard'] text-base text-[#1B1B1B]"
-  >
+const AuthLabel = ({ labelName, inputName }: AuthLabelProps) => (
+  <label htmlFor={inputName} className="text-base text-[#1B1B1B]">
     {labelName}
   </label>
 );

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -19,7 +19,9 @@ const LoginForm = () => {
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (password.length < PASSWORD_MIN_LENGTH && email.length !== 0) {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (password.length < PASSWORD_MIN_LENGTH && emailRegex.test(email)) {
       setLoginErrorMessages((prev) => ({
         ...prev,
         passwordErrorMessage: '8자 이상 작성해 주세요.',

--- a/src/components/login/LoginInputBox.tsx
+++ b/src/components/login/LoginInputBox.tsx
@@ -23,18 +23,12 @@ const LoginInputBox = ({
   const [inputType, setInputType] = useState(inputName);
 
   const onClickInput = () => {
-    if (inputName === 'email') {
-      setLoginErrorMessages((prev) => ({
-        ...prev,
-        emailErrorMessage: '',
-      }));
-    } else {
-      setLoginErrorMessages((prev) => ({
-        ...prev,
-        passwordErrorMessage: '',
-      }));
-    }
+    setLoginErrorMessages((prev) => ({
+      ...prev,
+      [`${inputName}ErrorMessage`]: '',
+    }));
   };
+
   const onClickEyeIcon = () => {
     if (inputType === 'password') {
       setInputType('text');

--- a/src/components/login/LoginInputBox.tsx
+++ b/src/components/login/LoginInputBox.tsx
@@ -47,7 +47,7 @@ const LoginInputBox = ({
 
   return (
     <div className="flex flex-col gap-2 relative">
-      <AuthLabel labelName={labelName} />
+      <AuthLabel labelName={labelName} inputName={inputName} />
       <div className="relative">
         <input
           name={inputName}

--- a/src/components/signup/LinkToLoginPage.tsx
+++ b/src/components/signup/LinkToLoginPage.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 
 const LinkToLoginPage = () => (
-  <div className="flex mx-auto my-0 w-[640px] items-center justify-center gap-2 font-normal mt-8">
+  <div className="flex mx-auto my-0 w-[640px] items-center justify-center gap-2 font-normal mt-8 sm:w-[350px]">
     <div className="text-[#4B4B4B]">회원이신가요?</div>
     <Link to="/login" className="text-green-80 underline underline-offset-2">
       로그인하기

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -1,143 +1,21 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent } from 'react';
 
-import { useMutation } from '@tanstack/react-query';
-import handleSignup from '@/api/handleSignup';
-
-import { SignupErrorType } from '@/types/signupPage';
-import { AxiosError } from 'axios';
 import useSignupInput from '@/hooks/useSignupInput';
+import useSignup from '@/hooks/useSignup';
 import AuthButton from '../common/auth/AuthButton';
 import SignupInputBox from './SignupInputBox';
 
 const SignupForm = () => {
   // custom hook
   const { inputs, onChangeInput } = useSignupInput();
+
   const { email, nickname, password, passwordConfirm } = inputs;
 
-  // 비밀번호 최소길이
-  const PASSWORD_MIN_LENGTH = 8;
-
-  const [signupErrorMessage, setSignupErrorMessage] = useState<SignupErrorType>({
-    emailErrorMessage: null,
-    nicknameErrorMessage: null,
-    passwordErrorMessage: null,
-    passwordConfirmErrorMessage: null,
-    unexpectedErrorMessage: null,
-  });
-
-  const { mutate } = useMutation({
-    mutationFn: handleSignup,
-    onSuccess: () => {
-      setSignupErrorMessage({
-        emailErrorMessage: null,
-        nicknameErrorMessage: null,
-        passwordErrorMessage: null,
-        passwordConfirmErrorMessage: null,
-        unexpectedErrorMessage: null,
-      });
-      alert('회원가입이 완료 되었습니다');
-    },
-    onError: (error: AxiosError) => {
-      if (error.response) {
-        const { email, nickname, password } = inputs;
-
-        if (error.response.status === 409) {
-          setSignupErrorMessage({
-            emailErrorMessage: '중복된 이메일입니다.',
-            nicknameErrorMessage: null,
-            passwordErrorMessage: null,
-            passwordConfirmErrorMessage: null,
-            unexpectedErrorMessage: null,
-          });
-        } else if (error.request.status === 400) {
-          // 이메일 확인
-          if (email.length === 0) {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              emailErrorMessage: '이메일을 입력해주세요.',
-            }));
-          } else if (!emailRegex.test(email)) {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              emailErrorMessage: '이메일 형식으로 작성해주세요.',
-            }));
-          } else {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              emailErrorMessage: null,
-            }));
-          }
-
-          // 닉네임 확인
-          if (nickname.length === 0) {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              nicknameErrorMessage: '닉네임을 입력해주세요.',
-            }));
-          } else if (nickname.length > 10) {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              nicknameErrorMessage: '닉네임은 10자 이하로 작성해주세요.',
-            }));
-          } else {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              nicknameErrorMessage: null,
-            }));
-          }
-
-          // 비밀번호 확인
-          if (password.length === 0) {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              passwordErrorMessage: '비밀번호를 입력해주세요.',
-            }));
-          } else if (password.length > 0 && password.length < PASSWORD_MIN_LENGTH) {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              passwordErrorMessage: '8자 이상 작성해 주세요.',
-            }));
-          } else {
-            setSignupErrorMessage((prev) => ({
-              ...prev,
-              passwordErrorMessage: null,
-            }));
-          }
-        }
-      }
-    },
-  });
+  const { mutation, signupErrorMessages, setSignupErrorMessages } = useSignup();
+  const { mutate } = mutation;
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-
-    if (password !== passwordConfirm) {
-      if (password.length > 0 && password.length < PASSWORD_MIN_LENGTH) {
-        setSignupErrorMessage((prev) => ({
-          ...prev,
-          passwordErrorMessage: '8자 이상 작성해 주세요.',
-        }));
-      }
-      if (passwordConfirm.length === 0) {
-        setSignupErrorMessage((prev) => ({
-          ...prev,
-          passwordConfirmErrorMessage: '비밀번호 확인값을 입력해주세요.',
-        }));
-      } else {
-        setSignupErrorMessage((prev) => ({
-          ...prev,
-          passwordConfirmErrorMessage: '비밀번호가 일치하지 않습니다.',
-        }));
-      }
-
-      return;
-    }
-
-    // 비밀번호가 일치하면 에러 메시지 초기화
-    setSignupErrorMessage((prev) => ({
-      ...prev,
-      passwordConfirmErrorMessage: null,
-    }));
 
     mutate({ email, nickname, password });
   };
@@ -151,8 +29,8 @@ const SignupForm = () => {
           value={email}
           labelName="이메일"
           inputType="email"
-          signupErrorMessage={signupErrorMessage}
-          setSignupErrorMessage={setSignupErrorMessage}
+          signupErrorMessages={signupErrorMessages}
+          setSignupErrorMessages={setSignupErrorMessages}
         />
         <SignupInputBox
           inputName="nickname"
@@ -160,8 +38,8 @@ const SignupForm = () => {
           value={nickname}
           labelName="닉네임"
           inputType="text"
-          signupErrorMessage={signupErrorMessage}
-          setSignupErrorMessage={setSignupErrorMessage}
+          signupErrorMessages={signupErrorMessages}
+          setSignupErrorMessages={setSignupErrorMessages}
         />
         <SignupInputBox
           inputName="password"
@@ -169,8 +47,8 @@ const SignupForm = () => {
           value={password}
           labelName="비밀번호"
           inputType="password"
-          signupErrorMessage={signupErrorMessage}
-          setSignupErrorMessage={setSignupErrorMessage}
+          signupErrorMessages={signupErrorMessages}
+          setSignupErrorMessages={setSignupErrorMessages}
         />
         <SignupInputBox
           inputName="passwordConfirm"
@@ -178,8 +56,8 @@ const SignupForm = () => {
           value={passwordConfirm}
           labelName="비밀번호 확인"
           inputType="password"
-          signupErrorMessage={signupErrorMessage}
-          setSignupErrorMessage={setSignupErrorMessage}
+          signupErrorMessages={signupErrorMessages}
+          setSignupErrorMessages={setSignupErrorMessages}
         />
         <AuthButton>회원가입</AuthButton>
       </form>

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -2,8 +2,9 @@ import { FormEvent } from 'react';
 
 import useSignupInput from '@/hooks/useSignupInput';
 import useSignup from '@/hooks/useSignup';
-import AuthButton from '../common/auth/AuthButton';
+
 import SignupInputBox from './SignupInputBox';
+import SignupSubmitButton from './SignupSubmitButton';
 
 const SignupForm = () => {
   // custom hook
@@ -14,54 +15,67 @@ const SignupForm = () => {
   const { mutation, signupErrorMessages, setSignupErrorMessages } = useSignup();
   const { mutate } = mutation;
 
+  const isButtonDisabled = !email || !nickname || !password || !passwordConfirm;
+
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+    if (
+      password !== passwordConfirm &&
+      emailRegex.test(email) &&
+      password.length >= 8 &&
+      nickname.length < 10
+    ) {
+      setSignupErrorMessages((prev) => ({
+        ...prev,
+        passwordConfirmErrorMessage: '비밀번호가 일치하지 않습니다',
+      }));
+      return;
+    }
     mutate({ email, nickname, password });
   };
 
   return (
-    <div>
-      <form onSubmit={onSubmit} className="flex flex-col gap-7 w-[40rem] mx-auto" noValidate>
-        <SignupInputBox
-          inputName="email"
-          onChangeInput={onChangeInput}
-          value={email}
-          labelName="이메일"
-          inputType="email"
-          signupErrorMessages={signupErrorMessages}
-          setSignupErrorMessages={setSignupErrorMessages}
-        />
-        <SignupInputBox
-          inputName="nickname"
-          onChangeInput={onChangeInput}
-          value={nickname}
-          labelName="닉네임"
-          inputType="text"
-          signupErrorMessages={signupErrorMessages}
-          setSignupErrorMessages={setSignupErrorMessages}
-        />
-        <SignupInputBox
-          inputName="password"
-          onChangeInput={onChangeInput}
-          value={password}
-          labelName="비밀번호"
-          inputType="password"
-          signupErrorMessages={signupErrorMessages}
-          setSignupErrorMessages={setSignupErrorMessages}
-        />
-        <SignupInputBox
-          inputName="passwordConfirm"
-          onChangeInput={onChangeInput}
-          value={passwordConfirm}
-          labelName="비밀번호 확인"
-          inputType="password"
-          signupErrorMessages={signupErrorMessages}
-          setSignupErrorMessages={setSignupErrorMessages}
-        />
-        <AuthButton>회원가입</AuthButton>
-      </form>
-    </div>
+    <form
+      onSubmit={onSubmit}
+      className="flex flex-col gap-7 w-[40rem] mx-auto mt-[40px] md:w-[640px] sm:w-[350px] sm:mt-6"
+      noValidate
+    >
+      <SignupInputBox
+        inputName="email"
+        onChangeInput={onChangeInput}
+        value={email}
+        labelName="이메일"
+        signupErrorMessages={signupErrorMessages}
+        setSignupErrorMessages={setSignupErrorMessages}
+      />
+      <SignupInputBox
+        inputName="nickname"
+        onChangeInput={onChangeInput}
+        value={nickname}
+        labelName="닉네임"
+        signupErrorMessages={signupErrorMessages}
+        setSignupErrorMessages={setSignupErrorMessages}
+      />
+      <SignupInputBox
+        inputName="password"
+        onChangeInput={onChangeInput}
+        value={password}
+        labelName="비밀번호"
+        signupErrorMessages={signupErrorMessages}
+        setSignupErrorMessages={setSignupErrorMessages}
+      />
+      <SignupInputBox
+        inputName="passwordConfirm"
+        onChangeInput={onChangeInput}
+        value={passwordConfirm}
+        labelName="비밀번호 확인"
+        signupErrorMessages={signupErrorMessages}
+        setSignupErrorMessages={setSignupErrorMessages}
+      />
+      <SignupSubmitButton disabled={isButtonDisabled}>회원가입</SignupSubmitButton>
+    </form>
   );
 };
 

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -1,16 +1,18 @@
-import { ChangeEvent, FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 
 import { useMutation } from '@tanstack/react-query';
 import handleSignup from '@/api/handleSignup';
 
 import { SignupErrorType } from '@/types/signupPage';
 import { AxiosError } from 'axios';
+import useSignupInput from '@/hooks/useSignupInput';
 import AuthButton from '../common/auth/AuthButton';
 import SignupInputBox from './SignupInputBox';
 
 const SignupForm = () => {
-  // 이메일 정규식
-  const emailRegex = /[a-z0-9]+@[a-z]+\.[a-z]{2,3}/;
+  // custom hook
+  const { inputs, onChangeInput } = useSignupInput();
+  const { email, nickname, password, passwordConfirm } = inputs;
 
   // 비밀번호 최소길이
   const PASSWORD_MIN_LENGTH = 8;
@@ -21,13 +23,6 @@ const SignupForm = () => {
     passwordErrorMessage: null,
     passwordConfirmErrorMessage: null,
     unexpectedErrorMessage: null,
-  });
-
-  const [inputs, setInputs] = useState({
-    email: '',
-    nickname: '',
-    password: '',
-    passwordConfirm: '',
   });
 
   const { mutate } = useMutation({
@@ -112,16 +107,6 @@ const SignupForm = () => {
       }
     },
   });
-
-  const { email, nickname, password, passwordConfirm } = inputs;
-
-  const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
-    const { value, name } = e.target;
-    setInputs({
-      ...inputs,
-      [name]: value,
-    });
-  };
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -29,7 +29,7 @@ const SignupForm = () => {
     ) {
       setSignupErrorMessages((prev) => ({
         ...prev,
-        passwordConfirmErrorMessage: '비밀번호가 일치하지 않습니다',
+        passwordConfirmErrorMessage: '비밀번호가 일치하지 않습니다.',
       }));
       return;
     }

--- a/src/components/signup/SignupInputBox.tsx
+++ b/src/components/signup/SignupInputBox.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useState } from 'react';
 
-import { SignupErrorType } from '@/types/signupPage';
+import { SignupErrorMessages } from '@/types/signupPage';
 import AuthLabel from '../common/auth/AuthLabel';
 
 interface SignupInputBoxProps {
@@ -9,8 +9,8 @@ interface SignupInputBoxProps {
   value: string;
   labelName: string;
   inputType: string;
-  signupErrorMessage: SignupErrorType | null;
-  setSignupErrorMessage: React.Dispatch<React.SetStateAction<SignupErrorType>>;
+  signupErrorMessages: SignupErrorMessages;
+  setSignupErrorMessages: React.Dispatch<React.SetStateAction<SignupErrorMessages>>;
 }
 
 const SignupInputBox = ({
@@ -19,34 +19,17 @@ const SignupInputBox = ({
   value,
   labelName,
   inputType,
-  signupErrorMessage,
-  setSignupErrorMessage,
+  signupErrorMessages,
+  setSignupErrorMessages,
 }: SignupInputBoxProps) => {
   const [isShowInputValue, setIsShowInputValue] = useState(false);
   const [changeInputType, setChangeInputType] = useState(inputType);
 
   const onClickInput = () => {
-    if (inputName === 'email') {
-      setSignupErrorMessage((prev) => ({
-        ...prev,
-        emailErrorMessage: null,
-      }));
-    } else if (inputName === 'nickname') {
-      setSignupErrorMessage((prev) => ({
-        ...prev,
-        nicknameErrorMessage: null,
-      }));
-    } else if (inputName === 'password') {
-      setSignupErrorMessage((prev) => ({
-        ...prev,
-        passwordErrorMessage: null,
-      }));
-    } else if (inputName === 'passwordConfirm') {
-      setSignupErrorMessage((prev) => ({
-        ...prev,
-        passwordConfirmErrorMessage: null,
-      }));
-    }
+    setSignupErrorMessages((prev) => ({
+      ...prev,
+      [`${inputName}ErrorMessage`]: '',
+    }));
   };
   const onClickEyeIcon = () => {
     if (labelName.includes('비밀번호')) {
@@ -57,13 +40,13 @@ const SignupInputBox = ({
     setIsShowInputValue((prev) => !prev);
   };
   let borderColorClass = '';
-  if (inputName === 'email' && signupErrorMessage?.emailErrorMessage) {
+  if (inputName === 'email' && signupErrorMessages?.emailErrorMessage) {
     borderColorClass = 'border-red-40';
-  } else if (inputName === 'nickname' && signupErrorMessage?.nicknameErrorMessage) {
+  } else if (inputName === 'nickname' && signupErrorMessages?.nicknameErrorMessage) {
     borderColorClass = 'border-red-40';
-  } else if (inputName === 'password' && signupErrorMessage?.passwordErrorMessage) {
+  } else if (inputName === 'password' && signupErrorMessages?.passwordErrorMessage) {
     borderColorClass = 'border-red-40';
-  } else if (inputName === 'passwordConfirm' && signupErrorMessage?.passwordConfirmErrorMessage) {
+  } else if (inputName === 'passwordConfirm' && signupErrorMessages?.passwordConfirmErrorMessage) {
     borderColorClass = 'border-red-40';
   }
   return (
@@ -97,29 +80,27 @@ const SignupInputBox = ({
           </button>
         ) : null}
       </div>
-      {inputName === 'email' && signupErrorMessage?.emailErrorMessage && (
-        <div className="text-red-40 text-xs ml-1">{signupErrorMessage.emailErrorMessage}</div>
+      {inputName === 'email' && signupErrorMessages?.emailErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">{signupErrorMessages.emailErrorMessage}</div>
       )}
-      {inputName === 'nickname' && signupErrorMessage?.nicknameErrorMessage && (
-        <div className="text-red-40 text-xs ml-1">{signupErrorMessage.nicknameErrorMessage}</div>
+      {inputName === 'nickname' && signupErrorMessages?.nicknameErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">{signupErrorMessages.nicknameErrorMessage}</div>
       )}
 
-      {inputName === 'password' && signupErrorMessage?.passwordErrorMessage && (
-        <div className="text-red-40 text-xs ml-1">{signupErrorMessage.passwordErrorMessage}</div>
+      {inputName === 'password' && signupErrorMessages?.passwordErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">{signupErrorMessages.passwordErrorMessage}</div>
       )}
-      {inputName === 'passwordConfirm' && signupErrorMessage?.passwordConfirmErrorMessage && (
+      {inputName === 'passwordConfirm' && signupErrorMessages?.passwordConfirmErrorMessage && (
         <div className="text-red-40 text-xs ml-1">
-          {signupErrorMessage.passwordConfirmErrorMessage}
+          {signupErrorMessages.passwordConfirmErrorMessage}
         </div>
       )}
 
-      {inputName === 'passwordConfirm' &&
-        signupErrorMessage?.passwordConfirmErrorMessage && (
-          <div className="text-red-40 text-xs ml-1">
-            {signupErrorMessage.passwordConfirmErrorMessage}
-          </div>
+      {inputName === 'passwordConfirm' && signupErrorMessages?.passwordConfirmErrorMessage && (
+        <div className="text-red-40 text-xs ml-1">
+          {signupErrorMessages.passwordConfirmErrorMessage}
+        </div>
       )}
-
     </div>
   );
 };

--- a/src/components/signup/SignupInputBox.tsx
+++ b/src/components/signup/SignupInputBox.tsx
@@ -1,30 +1,20 @@
-import { ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 
-import { SignupErrorMessages } from '@/types/signupPage';
+import { SignupInputBoxProps } from '@/types/signupPage';
 import AuthLabel from '../common/auth/AuthLabel';
-
-interface SignupInputBoxProps {
-  inputName: string;
-  onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void;
-  value: string;
-  labelName: string;
-  inputType: string;
-  signupErrorMessages: SignupErrorMessages;
-  setSignupErrorMessages: React.Dispatch<React.SetStateAction<SignupErrorMessages>>;
-}
 
 const SignupInputBox = ({
   inputName,
   onChangeInput,
   value,
   labelName,
-  inputType,
   signupErrorMessages,
   setSignupErrorMessages,
 }: SignupInputBoxProps) => {
   const [isShowInputValue, setIsShowInputValue] = useState(false);
-  const [changeInputType, setChangeInputType] = useState(inputType);
-
+  const [inputType, setInputType] = useState(
+    inputName.includes('password') ? 'password' : inputName,
+  );
   const onClickInput = () => {
     setSignupErrorMessages((prev) => ({
       ...prev,
@@ -32,10 +22,10 @@ const SignupInputBox = ({
     }));
   };
   const onClickEyeIcon = () => {
-    if (labelName.includes('비밀번호')) {
-      setChangeInputType('text');
+    if (inputType.includes('password')) {
+      setInputType('text');
     } else if (inputType === 'text') {
-      setChangeInputType('password');
+      setInputType('password');
     }
     setIsShowInputValue((prev) => !prev);
   };
@@ -51,15 +41,16 @@ const SignupInputBox = ({
   }
   return (
     <div className="flex flex-col gap-2 relative">
-      <AuthLabel labelName={labelName} />
+      <AuthLabel labelName={labelName} inputName={inputName} />
+
       <div className="relative">
         <input
           name={inputName}
-          type={changeInputType}
+          type={inputType}
           id={inputName}
           onChange={onChangeInput}
           value={value}
-          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass}`}
+          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass} focus:border-blue-500`}
           onClick={onClickInput}
         />
         {labelName.includes('비밀번호') === true ? (
@@ -90,12 +81,6 @@ const SignupInputBox = ({
       {inputName === 'password' && signupErrorMessages?.passwordErrorMessage && (
         <div className="text-red-40 text-xs ml-1">{signupErrorMessages.passwordErrorMessage}</div>
       )}
-      {inputName === 'passwordConfirm' && signupErrorMessages?.passwordConfirmErrorMessage && (
-        <div className="text-red-40 text-xs ml-1">
-          {signupErrorMessages.passwordConfirmErrorMessage}
-        </div>
-      )}
-
       {inputName === 'passwordConfirm' && signupErrorMessages?.passwordConfirmErrorMessage && (
         <div className="text-red-40 text-xs ml-1">
           {signupErrorMessages.passwordConfirmErrorMessage}

--- a/src/components/signup/SignupSubmitButton.tsx
+++ b/src/components/signup/SignupSubmitButton.tsx
@@ -1,0 +1,17 @@
+interface SignupSubmitButtonProps {
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+const SignupSubmitButton = ({ children, disabled = false }: SignupSubmitButtonProps) => (
+  <button
+    type="submit"
+    disabled={disabled}
+    className={`py-4 px-8 rounded-[6px] text-white text-lg font-semibold transition-opacity ${
+      disabled ? 'bg-gray-400' : 'bg-blue-500 hover:opacity-90'
+    }`}
+  >
+    {children}
+  </button>
+);
+
+export default SignupSubmitButton;

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -1,0 +1,64 @@
+import handleSignup from '@/api/handleSignup';
+import { HandleSignupParams, UserProfile, SignupErrorMessages } from '@/types/signupPage';
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+
+interface ErrorResponse {
+  message: string;
+}
+
+const useSignup = () => {
+  const [signupErrorMessages, setSignupErrorMessages] = useState<SignupErrorMessages>({
+    emailErrorMessage: '',
+    nicknameErrorMessage: '',
+    passwordErrorMessage: '',
+    passwordConfirmErrorMessage: '',
+  });
+
+  const navigate = useNavigate();
+  const mutation = useMutation<UserProfile, AxiosError, HandleSignupParams>({
+    mutationFn: handleSignup,
+    onSuccess: () => {
+      // 회원가입 성공 시 에러 메시지 초기화
+      setSignupErrorMessages({
+        emailErrorMessage: '',
+        nicknameErrorMessage: '',
+        passwordErrorMessage: '',
+        passwordConfirmErrorMessage: '',
+      });
+
+      // 회원가입 성공후 알림, 로그인 페이지로 이동
+      toast.success('회원가입에 성공했습니다!', {
+        onClose: () => navigate('/login'),
+        autoClose: 2000,
+      });
+    },
+    onError: (error) => {
+      if (error.response && error.response.data) {
+        const errorData = error.response.data as ErrorResponse;
+        const errorStatus = error.response.status;
+        const errorMessage = errorData.message;
+        if (errorStatus === 400) {
+          if (errorMessage.includes('이메일')) {
+            setSignupErrorMessages((prev) => ({ ...prev, emailErrorMessage: errorMessage }));
+          } else if (errorMessage.includes('닉네임')) {
+            setSignupErrorMessages((prev) => ({ ...prev, nicknameErrorMessage: errorMessage }));
+          } else if (errorMessage.includes('비밀번호')) {
+            setSignupErrorMessages((prev) => ({ ...prev, passwordErrorMessage: errorMessage }));
+          }
+        } else if (errorStatus === 409) {
+          setSignupErrorMessages((prev) => ({ ...prev, emailErrorMessage: errorMessage }));
+        }
+      } else {
+        setSignupErrorMessages((prev) => ({ ...prev, emailErrorMessage: error.message }));
+      }
+    },
+  });
+
+  return { mutation, signupErrorMessages, setSignupErrorMessages };
+};
+
+export default useSignup;

--- a/src/hooks/useSignupInput.ts
+++ b/src/hooks/useSignupInput.ts
@@ -1,0 +1,18 @@
+import { useState, ChangeEvent } from 'react';
+
+const useSignupInput = () => {
+  const [inputs, setInputs] = useState({
+    email: '',
+    nickname: '',
+    password: '',
+    passwordConfirm: '',
+  });
+  const onChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value, name } = e.target;
+    setInputs({ ...inputs, [name]: value });
+  };
+
+  return { inputs, onChangeInput };
+};
+
+export default useSignupInput;

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,16 +1,12 @@
+import AuthLayout from '@/components/common/auth/AuthLayout';
 import LinkToLoginPage from '../components/signup/LinkToLoginPage';
 import SignupForm from '../components/signup/SignupForm';
 
 const SignupPage = () => (
-  <div>
-    <img
-      src="/assets/logo.svg"
-      alt="logo"
-      className="ml-auto mr-auto mt-[104px] mb-[40px]"
-    />
+  <AuthLayout>
     <SignupForm />
     <LinkToLoginPage />
-  </div>
+  </AuthLayout>
 );
 
 export default SignupPage;

--- a/src/types/signupPage.ts
+++ b/src/types/signupPage.ts
@@ -12,3 +12,25 @@ export interface EditInformationErrorMessageType {
   passwordConfirmErrorMessage: string | null;
   unexpectedErrorMessage: string | null;
 }
+
+export interface HandleSignupParams {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+export interface UserProfile {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SignupErrorMessages {
+  emailErrorMessage: string;
+  nicknameErrorMessage: string;
+  passwordErrorMessage: string;
+  passwordConfirmErrorMessage: string;
+}

--- a/src/types/signupPage.ts
+++ b/src/types/signupPage.ts
@@ -1,3 +1,5 @@
+import { ChangeEvent } from 'react';
+
 export interface SignupErrorType {
   emailErrorMessage: string | null;
   nicknameErrorMessage: string | null;
@@ -33,4 +35,13 @@ export interface SignupErrorMessages {
   nicknameErrorMessage: string;
   passwordErrorMessage: string;
   passwordConfirmErrorMessage: string;
+}
+
+export interface SignupInputBoxProps {
+  inputName: string;
+  onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+  labelName: string;
+  signupErrorMessages: SignupErrorMessages;
+  setSignupErrorMessages: React.Dispatch<React.SetStateAction<SignupErrorMessages>>;
 }


### PR DESCRIPTION
## 💻 작업 내용

- 전체적으로 로그인 페이지와 유사한 방식으로 회원가입 페이지를 리팩터링 했습니다(error response 사용, 커스텀훅으로 관리) 
- 회원가입 페이지 반응형 디자인 추가
- 로그인 페이지와 동일하게 모든 인풋이 채워지지 않으면 버튼이 disabled 상태가 됩니다 
- 회원가입 성공시 toast로 회원가입에 성공했습니다 문구 표시후 로그인 페이지로 이동

## 🖼️ 스크린샷
![스크린샷 2024-06-15 153737](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/3809db17-be55-44aa-93f2-5ade8c978d8f)
PC
![스크린샷 2024-06-15 153906](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/76752e92-9674-4a51-81a6-38152c396166)
모바일
![Global Nomad - Chrome 2024-06-15 15-41-49](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/1764fbbd-d343-48e3-8d20-c97a935023b2)


## 🚨 관련 이슈 및 참고 사항

-
