### PR TITLE
[GNTF-97] localStorage를 이용해 최근 방문한 체험 리스트 구현

### DIFF
--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -9,8 +9,18 @@ interface ActivityCardProps {
 const ActivityCard = ({
   cardData: { id, title, price, bannerImageUrl, rating, reviewCount }
 }: ActivityCardProps) => {
+
+  const handleClick = () => {
+    localStorage.setItem('currentViewedActivity', JSON.stringify({ id, title, price, bannerImageUrl, rating, reviewCount }));
+  };
+
   return (
-    <Link to={`/activity/${id}`} className="group h-[435px] md:h-[373px] sm:h-[295px]" target="_blank">
+    <Link
+      to={`/activity/${id}`}
+      className="group h-[435px] md:h-[373px] sm:h-[295px]"
+      target="_blank"
+      onClick={handleClick}
+    >
       <div className="flex flex-col gap-4">
         <div
           className="w-[282px] h-[282px] bg-cover bg-center rounded-3xl group-hover:bg-extend md:w-[221px] md:h-[221px] sm:w-[168px] sm:h-[168px]"

--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -1,6 +1,7 @@
 import { ActivityInfo } from '@/types/mainPage';
 import { Link } from 'react-router-dom';
 import priceToWon from '@/utils/priceToWon';
+import { getCurrentViewedActivity, getRecentlyViewedActivities, setCurrentViewedActivity, setRecentlyViewedActivities } from '@/utils/saveRecentActivities';
 
 interface ActivityCardProps {
   cardData: ActivityInfo;
@@ -11,7 +12,22 @@ const ActivityCard = ({
 }: ActivityCardProps) => {
 
   const handleClick = () => {
-    localStorage.setItem('currentViewedActivity', JSON.stringify({ id, title, price, bannerImageUrl, rating, reviewCount }));
+    setCurrentViewedActivity({ id, title, price, bannerImageUrl, rating, reviewCount });
+    const viewedActivity = getCurrentViewedActivity();
+
+    if (viewedActivity) {
+      let viewedList = getRecentlyViewedActivities();
+
+      // 추가하려는 최근 본 체험과 중복된 체험이 목록에 있는지 확인
+      viewedList = viewedList.filter((activity: any) => activity.id !== viewedActivity.id);
+      viewedList.unshift(viewedActivity);
+
+      if (viewedList.length > 6) {
+        viewedList = viewedList.slice(0, 6);
+      }
+
+      setRecentlyViewedActivities(viewedList);
+    }
   };
 
   return (

--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -34,7 +34,6 @@ const ActivityCard = ({
     <Link
       to={`/activity/${id}`}
       className="group h-[435px] md:h-[373px] sm:h-[295px]"
-      target="_blank"
       onClick={handleClick}
     >
       <div className="flex flex-col gap-4">

--- a/src/components/mainpage/PopularActivityCard.tsx
+++ b/src/components/mainpage/PopularActivityCard.tsx
@@ -9,7 +9,7 @@ const PopularActivityCard = ({
   cardData: { id, title, price, bannerImageUrl, rating, reviewCount }
 }: PopularActivityCardProps) => {
   return (
-    <Link to={`/activity/${id}`} target="_blank">
+    <Link to={`/activity/${id}`}>
       <div className="relative">
         <div className="absolute bottom-8 left-5 flex flex-col gap-5 w-[230px] text-white z-10 sm:bottom-6 sm:w-[146px] sm:gap-[6px]">
           <div className="flex gap-1">

--- a/src/components/mainpage/RecentViewedActivity.tsx
+++ b/src/components/mainpage/RecentViewedActivity.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import '../../styles/customScrollbar.css';
+
+const getCurrentViewedActivity = () => {
+  const storedData = localStorage.getItem('currentViewedActivity');
+  return storedData ? JSON.parse(storedData) : null;
+};
+
+// Local storage에 최근 본 게시물 목록을 저장하는 함수
+const setRecentlyViewedActivities = (activity: any) => {
+  localStorage.setItem('recentlyViewedActivities', JSON.stringify(activity));
+};
+
+
+// Local storage에서 최근 본 게시물 목록을 가져오는 함수
+const getRecentlyViewedActivities = () => {
+  const storedData = localStorage.getItem('recentlyViewedActivities');
+  return storedData ? JSON.parse(storedData) : [];
+};
+
+
+const RecentViewedActivity = () => {
+  const [recentViewedList, setRecentViewedList] = useState([]);
+
+  useEffect(() => {
+    const viewedActivity = getCurrentViewedActivity();
+
+    if (viewedActivity) {
+      let viewedList = getRecentlyViewedActivities();
+      viewedList = viewedList.filter((activity: any) => activity.id !== viewedActivity.id);
+      viewedList.unshift(viewedActivity);
+      setRecentViewedList(viewedList);
+      setRecentlyViewedActivities(viewedList);
+    }
+  }, []);
+
+
+  return (
+    <div className="fixed top-4 right-4 rounded-2xl bg-white border border-green-80 p-4">
+      <div
+        className="w-36 h-48 flex flex-col items-center gap-3 overflow-y-scroll custom-scrollbar"
+      >
+        {recentViewedList.length ?
+          (recentViewedList.map((activity: any) => (
+            <Link key={activity.id} to={`/activity/${activity.id}`}>
+              <div
+                className="w-24 h-24 bg-cover bg-center rounded-3xl"
+                style={{ backgroundImage: `url(${activity.bannerImageUrl})` }}
+              />
+            </Link>
+          ))
+          ) : (
+            <div>최근에 본 체험 내역이 없습니다.</div>
+          )
+        }
+      </div>
+    </div>
+  );
+};
+
+export default RecentViewedActivity;

--- a/src/components/mainpage/RecentViewedActivity.tsx
+++ b/src/components/mainpage/RecentViewedActivity.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { CurrentViewedActivity, getRecentlyViewedActivities } from '@/utils/saveRecentActivities';
 import '../../styles/customScrollbar.css';
 
-const getRecentlyViewedActivities = () => {
-  const storedData = localStorage.getItem('recentlyViewedActivities');
-  return storedData ? JSON.parse(storedData) : [];
-};
-
 const RecentViewedActivity = () => {
+  const [showList, setShowList] = useState(false);
   const [recentViewedList, setRecentViewedList] = useState([]);
+
+  const handleClick = () => {
+    setShowList(!showList);
+  }
 
   useEffect(() => {
     const viewedList = getRecentlyViewedActivities();
@@ -16,25 +17,35 @@ const RecentViewedActivity = () => {
   }, []);
 
   return (
-    <div className="fixed top-4 right-4 rounded-2xl bg-white border border-green-80 p-4 z-10">
-      <div
-        className="w-36 h-48 flex flex-col items-center gap-3 overflow-y-scroll custom-scrollbar"
+    <>
+      <button
+        className="fixed top-1/2 -right-[2px]"
+        type='button'
+        onClick={handleClick}
       >
-        {recentViewedList.length ?
-          (recentViewedList.map((activity: any) => (
-            <Link key={activity.id} to={`/activity/${activity.id}`}>
-              <div
-                className="w-24 h-24 bg-cover bg-center rounded-3xl"
-                style={{ backgroundImage: `url(${activity.bannerImageUrl})` }}
-              />
-            </Link>
-          ))
-          ) : (
-            <div>최근에 본 체험 내역이 없습니다.</div>
-          )
-        }
-      </div>
-    </div>
+        <img src='/assets/pagination_arrow_left.svg' alt='show recent activity List'/>
+      </button>
+      {showList && <div className="fixed top-4 right-4 rounded-2xl bg-white border border-green-80 p-4 z-10">
+        <p className="text-lg text-center font-medium pb-2">최근 방문한 체험</p>
+        <div
+          className="w-36 h-48 flex flex-col items-center gap-3 overflow-y-scroll custom-scrollbar"
+        >
+          {recentViewedList.length ?
+            (recentViewedList.map((activity: CurrentViewedActivity) => (
+              <Link key={activity.id} to={`/activity/${activity.id}`}>
+                <div
+                  className="w-24 h-24 bg-cover bg-center rounded-3xl"
+                  style={{ backgroundImage: `url(${activity.bannerImageUrl})` }}
+                />
+              </Link>
+            ))
+            ) : (
+              <div>최근에 방문한 체험 내역이 없습니다.</div>
+            )
+          }
+        </div>
+      </div>}
+    </>
   );
 };
 

--- a/src/components/mainpage/RecentViewedActivity.tsx
+++ b/src/components/mainpage/RecentViewedActivity.tsx
@@ -2,42 +2,21 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import '../../styles/customScrollbar.css';
 
-const getCurrentViewedActivity = () => {
-  const storedData = localStorage.getItem('currentViewedActivity');
-  return storedData ? JSON.parse(storedData) : null;
-};
-
-// Local storage에 최근 본 게시물 목록을 저장하는 함수
-const setRecentlyViewedActivities = (activity: any) => {
-  localStorage.setItem('recentlyViewedActivities', JSON.stringify(activity));
-};
-
-
-// Local storage에서 최근 본 게시물 목록을 가져오는 함수
 const getRecentlyViewedActivities = () => {
   const storedData = localStorage.getItem('recentlyViewedActivities');
   return storedData ? JSON.parse(storedData) : [];
 };
 
-
 const RecentViewedActivity = () => {
   const [recentViewedList, setRecentViewedList] = useState([]);
 
   useEffect(() => {
-    const viewedActivity = getCurrentViewedActivity();
-
-    if (viewedActivity) {
-      let viewedList = getRecentlyViewedActivities();
-      viewedList = viewedList.filter((activity: any) => activity.id !== viewedActivity.id);
-      viewedList.unshift(viewedActivity);
-      setRecentViewedList(viewedList);
-      setRecentlyViewedActivities(viewedList);
-    }
+    const viewedList = getRecentlyViewedActivities();
+    setRecentViewedList(viewedList);
   }, []);
 
-
   return (
-    <div className="fixed top-4 right-4 rounded-2xl bg-white border border-green-80 p-4">
+    <div className="fixed top-4 right-4 rounded-2xl bg-white border border-green-80 p-4 z-10">
       <div
         className="w-36 h-48 flex flex-col items-center gap-3 overflow-y-scroll custom-scrollbar"
       >

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,12 +2,14 @@ import MainBanner from '@/components/mainpage/MainBanner';
 import ActivitySearch from '@/components/mainpage/ActivitySearch';
 import PopularActivityList from '@/components/mainpage/PopularActivityList';
 import ActivityCardList from '@/components/mainpage/ActivityCardList';
+import RecentViewedActivity from '@/components/mainpage/RecentViewedActivity';
 
 const MainPage = () => (
   <>
     <MainBanner />
     <section className="flex flex-col items-center">
       <div className="w-pc mb-32 md:w-tab sm:w-mob">
+        <RecentViewedActivity />
         <ActivitySearch />
         <PopularActivityList />
         <ActivityCardList />

--- a/src/utils/saveRecentActivities.ts
+++ b/src/utils/saveRecentActivities.ts
@@ -1,4 +1,4 @@
-type CurrentViewedActivity = {
+export type CurrentViewedActivity = {
   id: number;
   title: string;
   price: number;

--- a/src/utils/saveRecentActivities.ts
+++ b/src/utils/saveRecentActivities.ts
@@ -1,0 +1,31 @@
+type CurrentViewedActivity = {
+  id: number;
+  title: string;
+  price: number;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+};
+
+// 현재 본 게시물을 localStorage에 저장하는 함수
+export const setCurrentViewedActivity = (activity: CurrentViewedActivity) => {
+  localStorage.setItem('currentViewedActivity', JSON.stringify(activity));
+};
+
+// Local storage에 최근 본 게시물을 불러오는 함수
+export const getCurrentViewedActivity = () => {
+  const storedData = localStorage.getItem('currentViewedActivity');
+  return storedData ? JSON.parse(storedData) : null;
+};
+
+// Local storage에 최근 본 게시물 목록을 저장하는 함수
+export const setRecentlyViewedActivities = (activity: CurrentViewedActivity) => {
+  localStorage.setItem('recentlyViewedActivities', JSON.stringify(activity));
+};
+
+
+// Local storage에서 최근 본 게시물 목록을 가져오는 함수
+export const getRecentlyViewedActivities = () => {
+  const storedData = localStorage.getItem('recentlyViewedActivities');
+  return storedData ? JSON.parse(storedData) : [];
+};


### PR DESCRIPTION
## 💻 작업 내용

- localStorage를 이용해 최근 방문한 체험을 저장, 리스트를 보여줄 수 있도록 구현했습니다.
- 리스트 안에 있는 체험을 클릭 시 해당 체험 상세 페이지로 이동할 수 있도록 구현했습니다.
- 최근 방문한 체험 리스트는 오른쪽 사이드에 살짝 튀어나온 버튼을 누르면 맨 위쪽에 리스트가 나타나도록 구현이 되어 있습니다.


## 🖼️ 스크린샷
![스크린샷 2024-06-18 150935](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/4d7afc05-7298-4317-b7e3-2d3aadc5c55d)
![스크린샷 2024-06-18 150944](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/d24fa9cd-8341-4daf-b394-0eca5ef972d4)


## 🚨 관련 이슈 및 참고 사항

- zustand를 이용한 방법도 알아보았지만 제 생각에 최근 방문한 기록을 저장하는 것은 단순한 데이터 저장이기에 굳이 라이브러리를 쓸 이유가 없다고 판단이 되어 localStorage를 이용해 구현했습니다.
- 현재 구현된 UI는 임시입니다. 이후 차차 개선해나갈 예정입니다.
