### PR TITLE
[GNTF-99] 예약현황 페이지 수정

### DIFF
--- a/src/components/common/profile/MyPageLayout.tsx
+++ b/src/components/common/profile/MyPageLayout.tsx
@@ -17,7 +17,7 @@ const MyPageLayout = () => {
         isShowDefaultImage={isShowDefaultImage}
         setIsShowDefaultImage={setIsShowDefaultImage}
       />
-      <div className="w-[729px] sm:w-full">
+      <div className="w-[800px] sm:w-full">
         <Outlet context={{ uploadedImage, isShowProfileForm, isShowDefaultImage }} />
       </div>
     </div>

--- a/src/components/reserveStatus/ReserveStatusContent.tsx
+++ b/src/components/reserveStatus/ReserveStatusContent.tsx
@@ -119,13 +119,15 @@ const ReserveStatusContent = () => {
     if (matchedReservation) {
       const { completed, confirmed, pending } = matchedReservation.reservations;
       return (
-        <div onClick={() => onClickCalendarTile(date)}>
-          {pending !== 0 && <PendingTileBlock count={pending} />}
-          <br />
-          {completed !== 0 && <CompletedTileBlock count={completed} />}
-          <br />
-          {confirmed !== 0 && <ConfimedTileBlock count={confirmed} />}
-          <br />
+        <div className="w-full h-full text-left flex flex-col-reverse">
+          <div onClick={() => onClickCalendarTile(date)}>
+            {pending !== 0 && <PendingTileBlock count={pending} />}
+            {/* <br /> */}
+            {completed !== 0 && <CompletedTileBlock count={completed} />}
+            {/* <br /> */}
+            {confirmed !== 0 && <ConfimedTileBlock count={confirmed} />}
+            {/* <br /> */}
+          </div>
         </div>
       );
     }
@@ -134,7 +136,7 @@ const ReserveStatusContent = () => {
   };
 
   return (
-    <div className="w-[800px] relative">
+    <div className="w-full min-w-[21.375rem] relative">
       <h1 className="text-[32px] font-bold text-black mb-8">예약 현황</h1>
       {/* 드롭다운 박스에 선택된 activity title 표시 */}
       <ActivityDropDownBox

--- a/src/components/reserveStatus/ReserveStatusContent.tsx
+++ b/src/components/reserveStatus/ReserveStatusContent.tsx
@@ -122,11 +122,8 @@ const ReserveStatusContent = () => {
         <div className="w-full h-full text-left flex flex-col-reverse">
           <div onClick={() => onClickCalendarTile(date)}>
             {pending !== 0 && <PendingTileBlock count={pending} />}
-            {/* <br /> */}
             {completed !== 0 && <CompletedTileBlock count={completed} />}
-            {/* <br /> */}
             {confirmed !== 0 && <ConfimedTileBlock count={confirmed} />}
-            {/* <br /> */}
           </div>
         </div>
       );

--- a/src/components/reserveStatus/reservationModal/ReservationModal.tsx
+++ b/src/components/reserveStatus/reservationModal/ReservationModal.tsx
@@ -119,7 +119,7 @@ const ReservationModal = ({
       <div className="flex justify-between">
         <div className="font-bold text-[28px] text-[#1b1b1b]">예약정보</div>
         <button type="button" onClick={handleCloseModal}>
-          <img src="assets/x_btn.svg" alt="cancel_icon" />
+          <img src="/assets/x_btn.svg" alt="cancel_icon" />
         </button>
       </div>
       <div className="flex gap-3 mt-[34px] text-[20px] text-[#4b4b4b]">

--- a/src/components/reserveStatus/reservationModal/ScheduleTimeDropDownBox.tsx
+++ b/src/components/reserveStatus/reservationModal/ScheduleTimeDropDownBox.tsx
@@ -31,7 +31,7 @@ const ScheduleTimeDropDownBox = ({
       />
       <button type="button" className="cursor-pointer" onClick={handleClickDropDown}>
         <img
-          src="assets/chevron_down.svg"
+          src="/assets/chevron_down.svg"
           alt="drop_down_icon"
           className="absolute top-[18px] right-[10px]"
         />

--- a/src/styles/StyledReserveStatusCalendar.ts
+++ b/src/styles/StyledReserveStatusCalendar.ts
@@ -58,7 +58,7 @@ export const StyledReserveStatusCalendarWrapper = styled.div`
   .react-calendar__month-view__days__day {
     font-size: 13px;
     font-weight: 600;
-    padding: 10px;
+    padding: 2px;
   }
 
   /* 달력 타일 */
@@ -84,6 +84,13 @@ export const StyledReserveStatusCalendarWrapper = styled.div`
   /* 오늘 날짜 스타일 */
   .react-calendar__tile--now {
     border: 1px solid #0085ff;
+  }
+
+  @media (max-width: 768px) {
+    .react-calendar__month-view__days__day-names,
+    .react-calendar__month-view__days__day {
+      font-size: 11px;
+    }
   }
 `;
 


### PR DESCRIPTION
## 💻 작업 내용
- 예약현황 캘린더 전반적인 ui 수정 (캘린더 자체의 폭, 태그(완료,예약,승인)의 폭,위치,패딩)
- 예약현황 모달 이미지 안보이는 부분 수정


## 🖼️ 스크린샷
### 예약현황 캘린더 ui 수정 (pc버전)
<img width="1018" alt="스크린샷 2024-06-19 오전 12 19 55" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/d0221939-4711-4609-8494-29cca8903f4f">

### 예약현황 캘린더 ui 수정 (mobile버전)
<img width="423" alt="스크린샷 2024-06-19 오전 12 20 22" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/5f8b9395-70bd-4248-a9c2-c21b315aac93">

### 예약현황 모달 이미지 깨지는 부분 수정
<img width="1018" alt="스크린샷 2024-06-19 오전 12 21 11" src="https://github.com/Part4-Team15/GlobalNomad/assets/142493319/2bee54b6-0872-43ef-b4c6-3c1859b84a5b">



## 🚨 관련 이슈 및 참고 사항
-
