### PR TITLE
[GNTF-102] 로그인, 회원가입 페이지 리팩토링

### DIFF
--- a/src/components/common/auth/AuthButton.tsx
+++ b/src/components/common/auth/AuthButton.tsx
@@ -7,7 +7,7 @@ const AuthButton = ({ children, disabled = false }: AuthButtonProps) => (
     type="submit"
     disabled={disabled}
     className={`py-4 px-8 rounded-[6px] text-white text-lg font-semibold transition-opacity ${
-      disabled ? 'bg-gray-400' : 'bg-blue-500 hover:opacity-90'
+      disabled ? 'bg-gray-400' : 'bg-green-800 hover:opacity-90'
     }`}
   >
     {children}

--- a/src/components/signup/SignupSubmitButton.tsx
+++ b/src/components/signup/SignupSubmitButton.tsx
@@ -7,7 +7,7 @@ const SignupSubmitButton = ({ children, disabled = false }: SignupSubmitButtonPr
     type="submit"
     disabled={disabled}
     className={`py-4 px-8 rounded-[6px] text-white text-lg font-semibold transition-opacity ${
-      disabled ? 'bg-gray-400' : 'bg-blue-500 hover:opacity-90'
+      disabled ? 'bg-gray-400' : 'bg-green-800 hover:opacity-90'
     }`}
   >
     {children}

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -31,8 +31,8 @@ const useLogin = () => {
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
 
+      navigate('/');
       toast.success('로그인에 성공했습니다!', {
-        onClose: () => navigate('/'),
         autoClose: 2000,
       });
     },

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -31,8 +31,8 @@ const useSignup = () => {
       });
 
       // 회원가입 성공후 알림, 로그인 페이지로 이동
-      toast.success('회원가입에 성공했습니다!', {
-        onClose: () => navigate('/login'),
+      navigate('/');
+      toast.success('회원가입에 성공 했습니다!', {
         autoClose: 2000,
       });
     },


### PR DESCRIPTION
## 💻 작업 내용

- 멘토링때 나온 부분들을 수정했습니다

1. 버튼색 변경
2. 회원가입, 로그인 성공시 루트 페이지로 이동후에 toast로 알림 표시


## 🖼️ 스크린샷
![Global Nomad - Chrome 2024-06-19 15-35-30](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/700a439e-de71-4528-922e-51d8717f5a4d)

(회원가입 페이지도 동일하게 작동됩니다)


## 🚨 관련 이슈 및 참고 사항

-
