### PR TITLE
[GNTF-107] 맡은 페이지 다크모드 스타일링, 다크모드 버튼 배치 수정

### DIFF
--- a/src/components/common/auth/AuthLabel.tsx
+++ b/src/components/common/auth/AuthLabel.tsx
@@ -4,7 +4,7 @@ interface AuthLabelProps {
 }
 
 const AuthLabel = ({ labelName, inputName }: AuthLabelProps) => (
-  <label htmlFor={inputName} className="text-base text-[#1B1B1B]">
+  <label htmlFor={inputName} className="text-base text-[#1B1B1B] dark:text-darkMode-white-10">
     {labelName}
   </label>
 );

--- a/src/components/common/auth/AuthLayout.tsx
+++ b/src/components/common/auth/AuthLayout.tsx
@@ -1,10 +1,22 @@
 import { ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
 
-const AuthLayout = ({ children }: { children: ReactNode }) => (
-  <div className="pt-[104px] md:pt-[72px] sm:pt-[44px] md:px-[52px] sm:px-[12px] mb-[405px] md:mb-[490px] sm:mb-[259px]">
-    <img src="/assets/logo.svg" alt="logo" className="ml-auto mr-auto sm:w-[270px] sm:h-[154px]" />
-    {children}
-  </div>
-);
+const AuthLayout = ({ children }: { children: ReactNode }) => {
+  const location = useLocation(); // Changed navigate to location
+  console.log(location.pathname); // Use location instead of navigate
+
+  return (
+    <div
+      className={`pt-[104px] md:pt-[72px] sm:pt-[44px] md:px-[52px] sm:px-[12px] dark:bg-darkMode-black-10 ${location.pathname === '/login' ? 'h-screen' : 'h-full'}`}
+    >
+      <img
+        src="/assets/logo.svg"
+        alt="logo"
+        className="ml-auto mr-auto sm:w-[270px] sm:h-[154px]"
+      />
+      {children}
+    </div>
+  );
+};
 
 export default AuthLayout;

--- a/src/components/common/profile/MyPageLayout.tsx
+++ b/src/components/common/profile/MyPageLayout.tsx
@@ -8,7 +8,7 @@ const MyPageLayout = () => {
   const [isShowDefaultImage, setIsShowDefaultImage] = useState<boolean>(false);
 
   return (
-    <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[72px] md:px-6 md:justify-normal md:gap-4 sm:block sm:px-[16px] md:pt-[24px] sm:pt-[24px]">
+    <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[72px] md:px-6 md:justify-normal md:gap-4 sm:block sm:px-[16px] md:pt-[24px] sm:pt-[24px] dark:bg-darkMode-black-10">
       <MyPageProfile
         uploadedImage={uploadedImage}
         setUploadedImage={setUploadedImage}

--- a/src/components/common/profile/ProfileImageLayout.tsx
+++ b/src/components/common/profile/ProfileImageLayout.tsx
@@ -8,7 +8,7 @@ const ProfileImageLayout = ({
 }: ProfileImageLayoutProps) => {
   return (
     <div
-      className={`flex ${isShowProfile ? '' : 'sm:hidden'} md:w-[251px] lg:w-96 p-6 flex-col justify-center items-start gap-6 border rounded-xl border-gray-50 bg-white shadow-md self-start`}
+      className={`flex ${isShowProfile ? '' : 'sm:hidden'} md:w-[251px] lg:w-96 p-6 flex-col justify-center items-start gap-6 border rounded-xl border-gray-50 bg-white shadow-md self-start dark:bg-darkMode-black-20`}
     >
       <div className="flex justify-center items-start gap-[227px] self-stretch">
         <div className="flex flex-col justify-center items-center gap-6">{children}</div>

--- a/src/components/header/AuthLinkBox.tsx
+++ b/src/components/header/AuthLinkBox.tsx
@@ -1,9 +1,11 @@
 import { Link } from 'react-router-dom';
+import DarkModeButton from './DarkModeButton';
 
 const AuthLinkBox = () => (
   <nav className="flex gap-[25px] text-[14px] font-medium text-[#1B1B1B]">
     <Link to="/login">로그인</Link>
     <Link to="/signup">회원가입</Link>
+    <DarkModeButton />
   </nav>
 );
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,7 +1,6 @@
 import AuthLinkBox from './AuthLinkBox';
 import HeaderUserInformation from './HeaderUserInformation';
 import HeaderLogo from './HeaderLogo';
-import DarkModeButton from './DarkModeButton';
 
 const Header = () => {
   const accessToken = localStorage.getItem('accessToken');
@@ -11,7 +10,6 @@ const Header = () => {
   return (
     <header className="flex h-[70px] justify-around sm:px-[24px] sm:justify-between md:px-[24px] md:justify-between items-center dark:bg-darkMode-black-20 [&_*]:dark:text-darkMode-white-10">
       <HeaderLogo />
-      <DarkModeButton />
       {!isLogin ? <AuthLinkBox /> : <HeaderUserInformation />}
     </header>
   );

--- a/src/components/header/HeaderUserInformation.tsx
+++ b/src/components/header/HeaderUserInformation.tsx
@@ -1,3 +1,4 @@
+import DarkModeButton from './DarkModeButton';
 import HeaderProfile from './HeaderProfile';
 import Notification from './Notification';
 
@@ -6,6 +7,7 @@ const HeaderUserInformation = () => (
     <Notification />
     <img src="/assets/header_bar_icon.svg" alt="header_bar_icon" />
     <HeaderProfile />
+    <DarkModeButton />
   </div>
 );
 

--- a/src/components/header/NotificationDropdown.tsx
+++ b/src/components/header/NotificationDropdown.tsx
@@ -33,7 +33,7 @@ const NotificationDropdown = ({
   }, [inView, fetchNextPage]);
 
   return (
-    <div className="flex flex-col absolute top-[63px] right-[-100px] md:right-[-30px] z-20 w-[368px] rounded-md bg-green-10 shadow-md border-1 py-6 px-4 gap-3 h-[300px] overflow-y-auto sm:w-screen sm:top-0 sm:right-0 sm:fixed sm:inset-0 sm:h-screen sm:rounded-none">
+    <div className="flex flex-col absolute top-[63px] right-[-100px] md:right-[-30px] z-20 w-[368px] rounded-md bg-green-10 shadow-md border-1 py-6 px-4 gap-3 h-[300px] overflow-y-auto sm:w-screen sm:top-0 sm:right-0 sm:fixed sm:inset-0 sm:h-screen sm:rounded-none dark:bg-darkMode-black-20">
       {totalCount === 0 ? (
         <div>모든 알림을 확인했습니다!</div>
       ) : (

--- a/src/components/header/NotificationDropdownItem.tsx
+++ b/src/components/header/NotificationDropdownItem.tsx
@@ -22,7 +22,7 @@ const NotificationDropdownItem = ({
 
   const reservationStatus = content.slice(content.length - 8, content.length - 6);
   return (
-    <li className="w-full px-3 py-4 bg-white rounded-md sm:text-[20px]">
+    <li className="w-full px-3 py-4 bg-white rounded-md sm:text-[20px] dark:bg-darkMode-black-30">
       <div className="flex justify-between">
         <img
           src={`/assets/circle_${reservationStatus === '승인' ? 'blue' : 'red'}.svg`}

--- a/src/components/login/LinkToSignupPage.tsx
+++ b/src/components/login/LinkToSignupPage.tsx
@@ -2,8 +2,11 @@ import { Link } from 'react-router-dom';
 
 const LinkToSignupPage = () => (
   <div className="flex mx-auto my-0 w-[640px] items-center justify-center gap-2 font-normal mt-8 sm:w-[350px]">
-    <div className="text-[#4B4B4B]">회원이 아니신가요?</div>
-    <Link to="/signup" className="text-green-80 underline underline-offset-2">
+    <div className="text-[#4B4B4B] dark:text-darkMode-white-30">회원이 아니신가요?</div>
+    <Link
+      to="/signup"
+      className="text-green-80 underline underline-offset-2 dark:text-darkMode-gray-10"
+    >
       회원가입하기
     </Link>
   </div>

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -34,7 +34,7 @@ const LoginForm = () => {
   return (
     <form
       onSubmit={onSubmit}
-      className="flex flex-col gap-7 w-[40rem] mx-auto mt-[40px] md:w-[640px] sm:w-[350px] sm:mt-6"
+      className="flex flex-col gap-7 w-[40rem] mx-auto mt-[40px] md:w-[640px] sm:w-[350px] sm:mt-6 "
       noValidate
     >
       <LoginInputBox

--- a/src/components/login/LoginInputBox.tsx
+++ b/src/components/login/LoginInputBox.tsx
@@ -55,7 +55,7 @@ const LoginInputBox = ({
           id={inputName}
           onChange={onChangeInput}
           value={value}
-          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass} focus:border-blue-500`}
+          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass} focus:border-blue-500 dark:bg-darkMode-black-20 dark:text-darkMode-white-10`}
           onClick={onClickInput}
           placeholder={inputName === 'email' ? '이메일을 입력해주세요' : '비밀번호를 입력해 주세요'}
         />

--- a/src/components/myPage/MyPageForm.tsx
+++ b/src/components/myPage/MyPageForm.tsx
@@ -66,7 +66,9 @@ const MyPageForm = ({ uploadedImage, isShowProfileForm, isShowDefaultImage }: My
   return (
     <div className={`flex flex-col gap-4 ${isShowProfileForm ? '' : 'sm:hidden'} w-full`}>
       <div className="flex justify-between font-bold">
-        <h1 className="text-[#1b1b1b] text-[32px] w-[91px] h-[38px]">내정보</h1>
+        <h1 className="text-[#1b1b1b] text-[32px] w-[91px] h-[38px] dark:text-darkMode-white-10">
+          내정보
+        </h1>
         <button
           type="submit"
           form="myPageForm"

--- a/src/components/myPage/MyPageInputBox.tsx
+++ b/src/components/myPage/MyPageInputBox.tsx
@@ -39,7 +39,7 @@ const MyPageInputBox = ({
     <div className="flex flex-col gap-4">
       <MyPageInputLabel labelName={labelName} inputName={inputName} />
       <input
-        className={`py-4 pl-4 border border-gray-50 rounded ${borderColorClass} outline-none focus:border-blue-500 `}
+        className={`py-4 pl-4 border border-gray-50 rounded ${borderColorClass} outline-none focus:border-blue-500 dark:bg-darkMode-black-20 dark:text-darkMode-white-10`}
         type={inputType}
         id={inputName}
         onChange={onChangeInput}
@@ -51,19 +51,19 @@ const MyPageInputBox = ({
         onBlur={inputName === 'newPasswordConfirm' ? onFocusOut : undefined}
       />
       {inputName === 'nickname' && editProfileErrorMessages?.nicknameErrorMessage && (
-        <div className="text-red-40 text-xs ml-1">
+        <div className="text-red-40 text-xs ml-1 dark:text-darkMode-white-10">
           <p>{editProfileErrorMessages.nicknameErrorMessage}</p>
         </div>
       )}
 
       {inputName === 'newPassword' && editProfileErrorMessages?.newPasswordErrorMessage && (
-        <div className="text-red-40 text-xs ml-1">
+        <div className="text-red-40 text-xs ml-1 dark:text-darkMode-white-10">
           <p>{editProfileErrorMessages.newPasswordErrorMessage}</p>
         </div>
       )}
       {inputName === 'newPasswordConfirm' &&
         editProfileErrorMessages?.newPasswordConfirmErrorMessage && (
-          <div className="text-red-40 text-xs ml-1">
+          <div className="text-red-40 text-xs ml-1 dark:text-darkMode-white-10">
             <p>{editProfileErrorMessages.newPasswordConfirmErrorMessage}</p>
           </div>
         )}

--- a/src/components/myPage/MyPageInputLabel.tsx
+++ b/src/components/myPage/MyPageInputLabel.tsx
@@ -1,5 +1,8 @@
 const MyPageInputLabel = ({ labelName, inputName }: { labelName: string; inputName: string }) => (
-  <label htmlFor={inputName} className="font-bold text-[#1b1b1b] text-[24px]">
+  <label
+    htmlFor={inputName}
+    className="font-bold text-[#1b1b1b] text-[24px] dark:text-darkMode-white-10"
+  >
     {labelName}
   </label>
 );

--- a/src/components/myReservationHistory/ReservationContent.tsx
+++ b/src/components/myReservationHistory/ReservationContent.tsx
@@ -5,7 +5,9 @@ import ReservationList from './ReservationList';
 const ReservationContent = ({ status, setStatus, onReviewClick }: ReservationContentProps) => (
   <div className="flex w-full flex-col gap-6">
     <div className="flex justify-between">
-      <h1 className="font-bold text-[32px] text-[#1B1B1B]">예약 내역</h1>
+      <h1 className="font-bold text-[32px] text-[#1B1B1B] dark:text-darkMode-white-10">
+        예약 내역
+      </h1>
       <ReservationFilter setStatus={setStatus} />
     </div>
     <ReservationList status={status} onReviewClick={onReviewClick} />

--- a/src/components/myReservationHistory/ReservationDescrition.tsx
+++ b/src/components/myReservationHistory/ReservationDescrition.tsx
@@ -43,17 +43,17 @@ const ReservationDescription = ({
       <div className="font-bold mb-2 md:mb-0 sm:text-sm sm:mb-0" style={{ color: textColor }}>
         <p>{reservationStatusText}</p>
       </div>
-      <h2 className="text-xl font-bold text-[#112211] mb-3 md:mb-1 md:text-lg sm:text-sm">
+      <h2 className="text-xl font-bold text-[#112211] mb-3 md:mb-1 md:text-lg sm:text-sm dark:text-darkMode-white-10">
         {title}
       </h2>
       <div className="mb-4 text-[18px] text-[#112211] md:text-[14px] md:mb-[10px] sm:text-[12px] sm:mb-2">
-        <p>
+        <p className="dark:text-darkMode-white-10">
           {date} · {startTime} - {endTime} {headCount}명
         </p>
       </div>
       <div className="flex align-middle justify-between">
         <div className="text-[#1B1B1B] text-2xl font-bold py-[5px] md:text-[20px] sm:text-base sm:pt-0 sm:pb-[15px]">
-          <p>{priceToWon(totalPrice)}</p>
+          <p className="dark:text-darkMode-white-20">{priceToWon(totalPrice)}</p>
         </div>
         {status === 'completed' && (
           <button

--- a/src/components/myReservationHistory/ReservationDropdownFilterBox.tsx
+++ b/src/components/myReservationHistory/ReservationDropdownFilterBox.tsx
@@ -15,7 +15,7 @@ const ReservationDropdownFilterBox = ({
     <li>
       <button
         type="button"
-        className="px-[46px] py-[18px] w-[160px] text-[#4B4B4B]"
+        className="px-[46px] py-[18px] w-[160px] text-[#4B4B4B] dark:text-darkMode-white-10"
         onClick={handleFilterClick}
       >
         {statusKoreanName}

--- a/src/components/myReservationHistory/ReservationFilter.tsx
+++ b/src/components/myReservationHistory/ReservationFilter.tsx
@@ -28,12 +28,12 @@ const ReservationFilter = ({ setStatus }: ReservationFilterProps) => {
     <div
       onClick={toggleDropdown}
       ref={dropdownRef}
-      className="flex relative justify-between px-5 py-4 border-green-80 rounded-[15px] w-40 text-green-80 font-medium text-[18px] border-[1.5px] md:hidden sm:hidden cursor-pointer"
+      className="flex relative justify-between px-5 py-4 border-green-80 rounded-[15px] w-40 text-green-80 font-medium text-[18px] border-[1.5px] md:hidden sm:hidden cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
     >
       {selectedFilter}
       <img src="/assets/arrow_down.svg" alt="arrow_down" />
       {dropdownIsOpen && (
-        <ul className=" border-[1.5px] flex flex-col absolute top-[69.67px] rounded-[6px 6px 0px 0px] bg-white left-0 rounded-[6px] border-[#ddd] w-40 [&_li:not(:last-child)]:border-b-[1.5px] [&_li:not(:last-child)]:border-b-[#ddd]">
+        <ul className=" border-[1.5px] flex flex-col absolute top-[69.67px] rounded-[6px 6px 0px 0px] bg-white left-0 rounded-[6px] border-[#ddd] w-40 [&_li:not(:last-child)]:border-b-[1.5px] [&_li:not(:last-child)]:border-b-[#ddd] dark:bg-darkMode-black-20 dark:text-darkMode-white-10">
           {filterList.map((item) => {
             return (
               <ReservationDropdownFilterBox

--- a/src/components/myReservationHistory/ReservationItem.tsx
+++ b/src/components/myReservationHistory/ReservationItem.tsx
@@ -24,7 +24,7 @@ const ReservationItem = ({
   const formatDate = `${year}. ${month.replace(/^0/, '')}. ${day.replace(/^0/, '')}`;
 
   return (
-    <li className="flex rounded-3xl gap-6 overflow-hidden shadow-[0_4px_16px_0_rgba(17,34,17,0.05)] bg-white min-w-[21.5rem] md:h-[157px] md:gap-2 sm:h-[128px]">
+    <li className="flex rounded-3xl gap-6 overflow-hidden shadow-[0_4px_16px_0_rgba(17,34,17,0.05)] bg-white min-w-[21.5rem] md:h-[157px] md:gap-2 sm:h-[128px] dark:bg-darkMode-black-20">
       <img
         className="w-[204px] h-[204px] md:w-[157px] md:h-[157px] sm:w-[128px] sm:h-[128px]"
         src={`${bannerImageUrl}`}

--- a/src/components/signup/LinkToLoginPage.tsx
+++ b/src/components/signup/LinkToLoginPage.tsx
@@ -1,9 +1,12 @@
 import { Link } from 'react-router-dom';
 
 const LinkToLoginPage = () => (
-  <div className="flex mx-auto my-0 w-[640px] items-center justify-center gap-2 font-normal mt-8 sm:w-[350px]">
-    <div className="text-[#4B4B4B]">회원이신가요?</div>
-    <Link to="/login" className="text-green-80 underline underline-offset-2">
+  <div className="flex dark:bg-darkMode-black-10 my-0 items-center justify-center gap-2 font-normal pt-8 sm:w-[350px] w-[640px] mx-auto pb-[150px]">
+    <div className="text-[#4B4B4B] dark:text-darkMode-white-30">회원이신가요?</div>
+    <Link
+      to="/login"
+      className="text-green-80 underline underline-offset-2 dark:text-darkMode-gray-10"
+    >
       로그인하기
     </Link>
   </div>

--- a/src/components/signup/SignupForm.tsx
+++ b/src/components/signup/SignupForm.tsx
@@ -49,6 +49,7 @@ const SignupForm = () => {
         labelName="이메일"
         signupErrorMessages={signupErrorMessages}
         setSignupErrorMessages={setSignupErrorMessages}
+        placeholder="이메일을 입력해 주세요"
       />
       <SignupInputBox
         inputName="nickname"
@@ -57,6 +58,7 @@ const SignupForm = () => {
         labelName="닉네임"
         signupErrorMessages={signupErrorMessages}
         setSignupErrorMessages={setSignupErrorMessages}
+        placeholder="닉네임을 입력해 주세요"
       />
       <SignupInputBox
         inputName="password"
@@ -65,6 +67,7 @@ const SignupForm = () => {
         labelName="비밀번호"
         signupErrorMessages={signupErrorMessages}
         setSignupErrorMessages={setSignupErrorMessages}
+        placeholder="8자 이상 입력해 주세요"
       />
       <SignupInputBox
         inputName="passwordConfirm"
@@ -73,6 +76,7 @@ const SignupForm = () => {
         labelName="비밀번호 확인"
         signupErrorMessages={signupErrorMessages}
         setSignupErrorMessages={setSignupErrorMessages}
+        placeholder="비밀번호를 한번 더 입력해 주세요"
       />
       <SignupSubmitButton disabled={isButtonDisabled}>회원가입</SignupSubmitButton>
     </form>

--- a/src/components/signup/SignupInputBox.tsx
+++ b/src/components/signup/SignupInputBox.tsx
@@ -10,6 +10,7 @@ const SignupInputBox = ({
   labelName,
   signupErrorMessages,
   setSignupErrorMessages,
+  placeholder
 }: SignupInputBoxProps) => {
   const [isShowInputValue, setIsShowInputValue] = useState(false);
   const [inputType, setInputType] = useState(
@@ -50,8 +51,9 @@ const SignupInputBox = ({
           id={inputName}
           onChange={onChangeInput}
           value={value}
-          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass} focus:border-blue-500`}
+          className={`border border-gray-60 rounded-[6px] px-5 py-4 focus:outline-none w-full ${borderColorClass} focus:border-blue-500 dark:bg-darkMode-black-20 dark:text-darkMode-white-10`}
           onClick={onClickInput}
+          placeholder={placeholder}
         />
         {labelName.includes('비밀번호') === true ? (
           <button

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 const Layout = () => (
-  <div className="flex flex-col w-full min-h-screen [&_*]:transition [&_*]:duration-500">
+  <div className="flex flex-col w-full min-h-screen [&_*]:transition [&_*]:duration-500 ">
     <Header />
-    <div className="bg-gray-10 min-h-[calc(100vh-160px)]">
+    <div className="bg-gray-10 min-h-[calc(100vh-160px)] dark:bg-darkMode-black-10">
       <Outlet />
     </div>
     <Footer />

--- a/src/types/signupPage.ts
+++ b/src/types/signupPage.ts
@@ -44,4 +44,5 @@ export interface SignupInputBoxProps {
   labelName: string;
   signupErrorMessages: SignupErrorMessages;
   setSignupErrorMessages: React.Dispatch<React.SetStateAction<SignupErrorMessages>>;
+  placeholder: string;
 }


### PR DESCRIPTION
## 💻 작업 내용

 - 로그인, 회원가입, 알람 모달, 내정보, 예약 내역 다크모드 스타일링
- 다크모드 버튼 배치 수정

## 🖼️ 스크린샷
![스크린샷 2024-06-20 154235](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/09b43ec6-97dd-4bb3-9a32-d946f49cc75f)
내정보
![스크린샷 2024-06-20 154508](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/21a6d1c0-6924-42c4-9171-df4f43251569)
알림
![스크린샷 2024-06-20 154305](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/19fb6c2e-d8b8-4926-b167-1043a3e995d1)
로그인(회원가입 페이지 동일)

![스크린샷 2024-06-20 154254](https://github.com/Part4-Team15/GlobalNomad/assets/90647684/19aa2416-910f-47a7-9e68-415add460c48)
예약 내역


## 🚨 관련 이슈 및 참고 사항

- 메인 페이지 백그라운드는 지정 되있습니다
- 예약 현황 페이지 리팩토링후 스타일 작업 예정입니다
- 모달창도 잊지마시고 스타일링 해주세요!

