### PR TITLE
[GNTF-112] staleTime 옵션 추가 및 일부 UI 디자인 수정

### DIFF
--- a/src/components/mainpage/ActivityCardList.tsx
+++ b/src/components/mainpage/ActivityCardList.tsx
@@ -15,6 +15,7 @@ const usePageActivity = (pageNum: number, size: number, category: string, sort: 
   return useQuery({
     queryKey: queryKeys.currentPageActivity(pageNum, size, category, sort),
     queryFn: () => getCurrentPageActivity(pageNum, size, category, sort),
+    staleTime: 5 * 60 * 1000,
     placeholderData: keepPreviousData,
   });
 };

--- a/src/components/mainpage/ActivitySearch.tsx
+++ b/src/components/mainpage/ActivitySearch.tsx
@@ -22,15 +22,16 @@ const ActivitySearch = () => {
         onSubmit={handleSubmit}
       >
         <label className="text-black text-xl font-bold dark:text-darkMode-white-10 sm:text-base">무엇을 체험하고 싶으신가요?</label>
-        <div className="flex items-center gap-3">
-          <div className="group flex items-center w-[1004px] h-14 border border-gray-60 border-solid rounded-md
+        <div className="flex items-center gap-3 peer">
+          <div className="relative flex items-center w-[1004px] h-14 border border-gray-60 border-solid rounded-md
           lg:w-[952px] md:w-[500px] sm:w-[187px] focus-within:border-green-40 focus-within:dark:border-darkMode-white-30"
           >
             <div className="w-6 h-6 m-3 md:m-2 sm:m-2">
               <SearchIcon className="fill-green-80 dark:fill-darkMode-gray-10"/>
             </div>
+            {keyword && <p className="absolute -top-3 left-9 bg-white px-1 text-gray-70 dark:bg-darkMode-black-40 dark:text-darkMode-white-30">내가 원하는 체험은</p>}
             <input
-              className="outline-none w-[930px] dark:bg-darkMode-black-40 dark:text-darkMode-white-10 
+              className="outline-none w-[916px] placeholder:pl-1 dark:bg-darkMode-black-40 dark:text-darkMode-white-10 
               placeholder:dark:text-darkMode-white-10 lg:w-[730px] md:w-[436px] sm:w-[124px]"
               type="search"
               ref={searchWord}

--- a/src/components/mainpage/MainBanner.tsx
+++ b/src/components/mainpage/MainBanner.tsx
@@ -1,7 +1,10 @@
 const MainBanner = () => {
-  const calendarNum = 1;
+  const calendarNum = new Date().getMonth() + 1;
   return (
-    <div className="relative flex justify-center bg-cover bg-center w-full h-[600px] sm:h-[240px]" style={{ backgroundImage: "url('/assets/banner.jpg')" }}>
+    <div
+      className="relative flex justify-center bg-cover bg-center w-full h-[600px] sm:h-[240px]"
+      style={{ backgroundImage: "url('/assets/banner.jpg')" }}
+    >
       <div className="absolute inset-0 bg-black opacity-30 dark:bg-darkMode-gray-20" />
       <div className="w-pc flex flex-col justify-center px-2 z-10 lg:w-[1000px] lg:px-0 md:w-tab md:px-0 sm:w-mob sm:px-0">
         <div className="top-5 flex flex-col gap-5 w-[502px] md:w-[440px] sm:w-[184px]">

--- a/src/components/mainpage/PopularActivityCard.tsx
+++ b/src/components/mainpage/PopularActivityCard.tsx
@@ -38,7 +38,10 @@ const PopularActivityCard = ({
   return (
     <Link to={`/activity/${id}`} onClick={handleClick}>
       <div className="relative">
-        <div className="relative w-[380px] h-[380px] bg-cover bg-center bg-no-repeat rounded-3xl hover:bg-extend lg:w-[317px] lg:h-[317px] sm:w-[186px] sm:h-[186px]" style={{ backgroundImage: `url('${bannerImageUrl}')` }}>
+        <div
+          className="relative w-[380px] h-[380px] bg-cover bg-center bg-no-repeat rounded-3xl
+          hover:bg-extend lg:w-[317px] lg:h-[317px] sm:w-[186px] sm:h-[186px]"
+          style={{ backgroundImage: `url('${bannerImageUrl}')` }}>
           <div className="absolute inset-0 bg-black opacity-30 rounded-3xl" />
         </div>
         <div className="absolute bottom-8 left-5 flex flex-col gap-5 w-[230px] text-white sm:bottom-6 sm:w-[146px] sm:gap-[6px]">

--- a/src/components/mainpage/PopularActivityList.tsx
+++ b/src/components/mainpage/PopularActivityList.tsx
@@ -22,6 +22,7 @@ const PopularActivityList = () => {
   } = useQuery({
     queryKey: queryKeys.popularActivity(),
     queryFn: getPopularActivity,
+    staleTime: 5 * 60 * 1000,
   });
 
   if (isError || !popularActivityList) {

--- a/src/components/mainpage/SearchResultList.tsx
+++ b/src/components/mainpage/SearchResultList.tsx
@@ -13,6 +13,7 @@ const useSearchResult = (keyword: string, pageNum: number, size: number) => {
   return useQuery({
     queryKey: queryKeys.searchPageActivity(keyword, pageNum, size),
     queryFn: () => getSearchResult(keyword, pageNum, size),
+    staleTime: 5 * 60 * 1000,
     placeholderData: keepPreviousData,
   });
 };

--- a/src/components/mainpage/SearchResultList.tsx
+++ b/src/components/mainpage/SearchResultList.tsx
@@ -56,11 +56,11 @@ const SearchResultList = () => {
   return (
     <>
       <div className="flex flex-col gap-3 text-nomad-black mt-10 mb-6 md:my-6 sm:mt-6 sm:mb-4">
-        <h2 className="text-[2rem] sm:text-2xl sm:leading-normal">
-          <span className="font-bold text-green-40">{keyword}</span>
+        <h2 className="text-[2rem] dark:text-darkMode-white-10 sm:text-2xl sm:leading-normal">
+          <span className="font-bold text-green-40 ">{keyword}</span>
           으로 검색한 결과입니다.
         </h2>
-        <p className="sm:leading-[26px]">총 {totalCount}개의 결과</p>
+        <p className="dark:text-darkMode-white-10 sm:leading-[26px]">총 {totalCount}개의 결과</p>
       </div>
       {totalCount ? (
         <>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -6,8 +6,8 @@ const SearchResultPage = () => {
   return (
     <>
       <MainBanner />
-      <section className="flex flex-col items-center">
-        <div className="w-pc mb-[332px] md:w-tab md:mb-[782px] sm:w-mob sm:mb-[514px]">
+      <section className="flex flex-col justify-center items-center w-full">
+        <div className="min-w-pc mb-[332px] bg-gray-10 dark:bg-darkMode-black-10 md:w-tab md:mb-[782px] sm:w-mob sm:mb-[514px]">
           <ActivitySearch />
           <SearchResultList />
         </div>

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,18 +1,18 @@
 import ActivitySearch from '@/components/mainpage/ActivitySearch';
 import MainBanner from '@/components/mainpage/MainBanner';
+import RecentViewedActivity from '@/components/mainpage/RecentViewedActivity';
 import SearchResultList from '@/components/mainpage/SearchResultList';
 
 const SearchResultPage = () => {
   return (
-    <>
+    <div className="flex flex-col justify-center items-center w-full">
       <MainBanner />
-      <section className="flex flex-col justify-center items-center w-full">
-        <div className="min-w-pc mb-[332px] bg-gray-10 dark:bg-darkMode-black-10 md:w-tab md:mb-[782px] sm:w-mob sm:mb-[514px]">
-          <ActivitySearch />
-          <SearchResultList />
-        </div>
-      </section>
-    </>
+      <div className="min-w-pc mb-[332px] bg-gray-10 dark:bg-darkMode-black-10 md:w-tab md:mb-[782px] sm:w-mob sm:mb-[514px]">
+        <RecentViewedActivity />
+        <ActivitySearch />
+        <SearchResultList />
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 💻 작업 내용

- 불필요한 api 통신이 계속 일어나지 않도록 리액트 쿼리 옵션으로 staleTime을 5분 정도 주었습니다.
- 검색 페이지일 때 검색 창 UI 디자인을 피그마에 나와있는 것처럼 보일 수 있도록 변경했습니다.
- 검색 페이지에서도 최근 방문한 체험 리스트를 볼 수 있도록 컴포넌트를 추가했습니다.
- 검색 페이지에 다크모드 디자인을 적용했습니다.


## 🖼️ 스크린샷

![스크린샷 2024-06-21 155428](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/65587507-0a91-4391-8c71-222bba3d8450)
![스크린샷 2024-06-21 155533](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/30b4ce94-0558-417d-8e09-ab94eeaf756f)
![스크린샷 2024-06-21 155543](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/d4ce837c-2775-4db4-bd06-c8a62f20266f)


## 🚨 관련 이슈 및 참고 사항

- 배너 이미지의 1월의 인기체험 부분을 현재 달 수를 받아와서 적용할 수 있도록 변경했습니다.
