### PR TITLE
[GNTF-118] : 등록/수정 페이지 시간대, 주소, 이미지 리팩토링 + 등록수정시 쿼리 무효화 + 패딩값 적용 

### DIFF
--- a/src/api/postAssignImage.ts
+++ b/src/api/postAssignImage.ts
@@ -13,8 +13,9 @@ const postAssignImage = async (assignImage: FormData) => {
   } catch (e) {
     console.error('Error: ', e);
     if (axios.isAxiosError(e)) {
-      const errorMessage = e.response?.data?.message;
-      Toast.error(errorMessage);
+      if (e.message === 'Network Error') {
+        Toast.error('이미지 파일 용량이 큽니다.');
+      } else Toast.error(e.message);
     }
     return null;
   }

--- a/src/components/assignActivity/AssignAddress.tsx
+++ b/src/components/assignActivity/AssignAddress.tsx
@@ -47,9 +47,12 @@ const AssignAddress = () => {
           주소 찾기
         </button>
       </div>
-      <div className=" flex pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white dark:bg-darkMode-black-20 dark:text-darkMode-white-10">
+      <div
+        className=" flex pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+        onClick={handleOpenPost}
+      >
         <input
-          className="w-[100%] outline-none dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+          className="w-[100%] outline-none cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
           placeholder="주소를 입력해주세요"
           value={address}
           readOnly

--- a/src/components/assignActivity/AssignBannerImage.tsx
+++ b/src/components/assignActivity/AssignBannerImage.tsx
@@ -69,7 +69,7 @@ const AssignBannerImage = () => {
             }}
           >
             <img
-              className=" absolute top-[-10px] right-[-10px]"
+              className=" absolute top-[-10px] right-[-10px] cursor-pointer"
               src="/assets/white_x_btn.svg"
               alt="whiteXBtn"
               onClick={handleRemoveImage}

--- a/src/components/assignActivity/AssignIntroImage.tsx
+++ b/src/components/assignActivity/AssignIntroImage.tsx
@@ -89,7 +89,7 @@ const AssignIntroImage = () => {
               }}
             >
               <img
-                className=" absolute top-[-10px] right-[-10px]"
+                className=" absolute top-[-10px] right-[-10px] cursor-pointer"
                 src="/assets/white_x_btn.svg"
                 alt="whiteXBtn"
                 onClick={() => handleRemoveImage(index)}

--- a/src/components/assignActivity/AssignReservationTime.tsx
+++ b/src/components/assignActivity/AssignReservationTime.tsx
@@ -71,7 +71,7 @@ const AssignReservationTime = () => {
           </div>
 
           <img
-            className="mt-6 h-[46px]"
+            className="mt-6 h-[46px] cursor-pointer"
             src="/assets/plus_time_btn.svg"
             alt="plusTimeBtn"
             onClick={handleAssignTime}

--- a/src/components/assignActivity/reservation/ReservationDate.tsx
+++ b/src/components/assignActivity/reservation/ReservationDate.tsx
@@ -29,9 +29,12 @@ const ReservationDate = () => {
     <div className=" w-[100%] relative">
       <div className="flex w-[100%] flex-col">
         <label className="dark:text-darkMode-gray-10">날짜</label>
-        <div className=" flex w-[100%] pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white dark:bg-darkMode-black-20 dark:text-darkMode-white-10">
+        <div
+          className=" flex w-[100%] pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+          onClick={handleCalendar}
+        >
           <input
-            className="w-[100%] outline-none dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+            className="w-[100%] outline-none cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
             placeholder="YYYY-MM-DD"
             value={selectedDate}
             readOnly

--- a/src/components/assignActivity/reservation/ReservationEndTime.tsx
+++ b/src/components/assignActivity/reservation/ReservationEndTime.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import queryKeys from '@/api/reactQuery/queryKeys';
 import useMergeAssignData from '@/hooks/useMergeAssignData';
+import useClickOutside from '@/hooks/useClickOutside';
 import EndTimeDropDown from '../dropDown/EndTimeDropDown';
 
 const ReservationEndTime = () => {
   const { mergeEndTime } = useMergeAssignData();
   const [isEndTimeDropDown, setIsEndTimeDropDown] = useState<boolean>(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
   const { data: endTime = '' } = useQuery<string>({
     queryKey: queryKeys.assignEndTime(),
   });
@@ -21,8 +23,10 @@ const ReservationEndTime = () => {
     setIsEndTimeDropDown(!isEndTimeDropDown);
   };
 
+  useClickOutside(dropDownRef, () => setIsEndTimeDropDown(false));
+
   return (
-    <div className=" w-[100%] relative">
+    <div className=" w-[100%] relative" ref={dropDownRef}>
       <div className="flex w-[100%] flex-col ">
         <label className="dark:text-darkMode-gray-10">종료 시간</label>
         <div

--- a/src/components/assignActivity/reservation/ReservationForm.tsx
+++ b/src/components/assignActivity/reservation/ReservationForm.tsx
@@ -65,7 +65,7 @@ const ReservationForm = () => {
           </div>
 
           <img
-            className="h-[46px]"
+            className="h-[46px] cursor-pointer"
             src="/assets/minus_time_btn.svg"
             alt="minusTimeBtn"
             onClick={() => handleRemoveReservationTime(index)}

--- a/src/components/assignActivity/reservation/ReservationStartTime.tsx
+++ b/src/components/assignActivity/reservation/ReservationStartTime.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import queryKeys from '@/api/reactQuery/queryKeys';
 import useMergeAssignData from '@/hooks/useMergeAssignData';
+import useClickOutside from '@/hooks/useClickOutside';
 import StartTimeDropDown from '../dropDown/StartTimeDropDown';
 
 const ReservationStartTime = () => {
   const { mergeStartTime } = useMergeAssignData();
   const [isStartTimeDropDown, setIsStartTimeDropDown] = useState<boolean>(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
 
   const { data: startTime = '' } = useQuery<string>({
     queryKey: queryKeys.assignStartTime(),
@@ -22,8 +24,10 @@ const ReservationStartTime = () => {
     setIsStartTimeDropDown(!isStartTimeDropDown);
   };
 
+  useClickOutside(dropDownRef, () => setIsStartTimeDropDown(false));
+
   return (
-    <div className=" w-[100%] relative">
+    <div className=" w-[100%] relative" ref={dropDownRef}>
       <div className="flex w-[100%] flex-col ">
         <label className="dark:text-darkMode-gray-10">시작 시간</label>
         <div

--- a/src/components/common/profile/MyPageLayout.tsx
+++ b/src/components/common/profile/MyPageLayout.tsx
@@ -8,7 +8,7 @@ const MyPageLayout = () => {
   const [isShowDefaultImage, setIsShowDefaultImage] = useState<boolean>(false);
 
   return (
-    <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[72px] md:px-6 md:justify-normal md:gap-4 sm:block sm:px-[16px] md:pt-[24px] sm:pt-[24px] dark:bg-darkMode-black-10">
+    <div className="flex gap-6 justify-center bg-[#FAFAFA] pt-[72px] pb-[72px] md:px-6 md:justify-normal md:gap-4 sm:block sm:px-[16px] md:pt-[24px] sm:pt-[24px] md:pb-[24px] sm:pb-[24px] dark:bg-darkMode-black-10">
       <MyPageProfile
         uploadedImage={uploadedImage}
         setUploadedImage={setUploadedImage}

--- a/src/components/modifyActivity/ModifyAddress.tsx
+++ b/src/components/modifyActivity/ModifyAddress.tsx
@@ -56,9 +56,12 @@ const ModifyAddress = ({ address }: ModifyAddressProps) => {
           주소 찾기
         </button>
       </div>
-      <div className=" flex pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white dark:bg-darkMode-black-20 dark:text-darkMode-white-10">
+      <div
+        className=" flex pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+        onClick={handleOpenPost}
+      >
         <input
-          className="w-[100%] outline-none dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+          className="w-[100%] outline-none cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
           placeholder="주소를 입력해주세요"
           value={localAddress}
           readOnly

--- a/src/components/modifyActivity/ModifyBannerImage.tsx
+++ b/src/components/modifyActivity/ModifyBannerImage.tsx
@@ -78,7 +78,7 @@ const ModifyBannerImage = ({ bannerImageUrl }: ModifyBannerImageProps) => {
             }}
           >
             <img
-              className=" absolute top-[-10px] right-[-10px]"
+              className=" absolute top-[-10px] right-[-10px] cursor-pointer"
               src="/assets/white_x_btn.svg"
               alt="whiteXBtn"
               onClick={handleRemoveImage}

--- a/src/components/modifyActivity/ModifyIntroImage.tsx
+++ b/src/components/modifyActivity/ModifyIntroImage.tsx
@@ -102,7 +102,7 @@ const ModifyIntroImage = ({ subImages }: ModifyIntroImageProps) => {
               }}
             >
               <img
-                className=" absolute top-[-10px] right-[-10px]"
+                className=" absolute top-[-10px] right-[-10px] cursor-pointer"
                 src="/assets/white_x_btn.svg"
                 alt="whiteXBtn"
                 onClick={() => handleRemoveImage(index)}

--- a/src/components/modifyActivity/ModifyReservationTime.tsx
+++ b/src/components/modifyActivity/ModifyReservationTime.tsx
@@ -85,7 +85,7 @@ const ModifyReservationTime = ({ schedules }: ModifyReservationTimeProps) => {
           </div>
 
           <img
-            className="mt-6 h-[46px]"
+            className="mt-6 h-[46px] cursor-pointer"
             src="/assets/plus_time_btn.svg"
             alt="plusTimeBtn"
             onClick={handleAssignTime}

--- a/src/components/modifyActivity/reservation/ReservationDate.tsx
+++ b/src/components/modifyActivity/reservation/ReservationDate.tsx
@@ -31,9 +31,12 @@ const ReservationDate = () => {
     <div className=" w-[100%] relative">
       <div className="flex w-[100%] flex-col">
         <label className="dark:text-darkMode-gray-10">날짜</label>
-        <div className=" flex w-[100%] pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white dark:bg-darkMode-black-20 dark:text-darkMode-white-10">
+        <div
+          className=" flex w-[100%] pt-2 pr-4 pb-2 pl-4 items-center self-stretch rounded-[4px] border border-gray-60 bg-white cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+          onClick={handleCalendar}
+        >
           <input
-            className="w-[100%] outline-none dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
+            className="w-[100%] outline-none cursor-pointer dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
             placeholder="YYYY-MM-DD"
             value={selectedDate}
             readOnly

--- a/src/components/modifyActivity/reservation/ReservationEndTime.tsx
+++ b/src/components/modifyActivity/reservation/ReservationEndTime.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import queryKeys from '@/api/reactQuery/queryKeys';
 import useMergeModifyData from '@/hooks/useMergeModifyData';
+import useClickOutside from '@/hooks/useClickOutside';
 import EndTimeDropDown from '../dropDown/EndTimeDropDown';
 
 const ReservationEndTime = () => {
   const { mergeEndTime } = useMergeModifyData();
   const [isEndTimeDropDown, setIsEndTimeDropDown] = useState<boolean>(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
   const { data: endTime = '' } = useQuery<string>({
     queryKey: queryKeys.modifyScheduleEndTime(),
   });
@@ -21,8 +23,10 @@ const ReservationEndTime = () => {
     setIsEndTimeDropDown(!isEndTimeDropDown);
   };
 
+  useClickOutside(dropDownRef, () => setIsEndTimeDropDown(false));
+
   return (
-    <div className=" w-[100%] relative">
+    <div className=" w-[100%] relative" ref={dropDownRef}>
       <div className="flex w-[100%] flex-col ">
         <label className="dark:text-darkMode-gray-10">종료 시간</label>
         <div

--- a/src/components/modifyActivity/reservation/ReservationForm.tsx
+++ b/src/components/modifyActivity/reservation/ReservationForm.tsx
@@ -76,7 +76,7 @@ const ReservationForm = () => {
           </div>
 
           <img
-            className="h-[46px]"
+            className="h-[46px] cursor-pointer"
             src="/assets/minus_time_btn.svg"
             alt="minusTimeBtn"
             onClick={() => handleRemoveReservationTime(index)}

--- a/src/components/modifyActivity/reservation/ReservationStartTime.tsx
+++ b/src/components/modifyActivity/reservation/ReservationStartTime.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import queryKeys from '@/api/reactQuery/queryKeys';
 import useMergeModifyData from '@/hooks/useMergeModifyData';
+import useClickOutside from '@/hooks/useClickOutside';
 import StartTimeDropDown from '../dropDown/StartTimeDropDown';
 
 const ReservationStartTime = () => {
   const { mergeStartTime } = useMergeModifyData();
   const [isStartTimeDropDown, setIsStartTimeDropDown] = useState<boolean>(false);
+  const dropDownRef = useRef<HTMLDivElement>(null);
 
   const { data: startTime = '' } = useQuery<string>({
     queryKey: queryKeys.modifyScheduleStartTime(),
@@ -22,8 +24,10 @@ const ReservationStartTime = () => {
     setIsStartTimeDropDown(!isStartTimeDropDown);
   };
 
+  useClickOutside(dropDownRef, () => setIsStartTimeDropDown(false));
+
   return (
-    <div className=" w-[100%] relative">
+    <div className=" w-[100%] relative" ref={dropDownRef}>
       <div className="flex w-[100%] flex-col ">
         <label className="dark:text-darkMode-gray-10">시작 시간</label>
         <div

--- a/src/hooks/useMutateAssignData.ts
+++ b/src/hooks/useMutateAssignData.ts
@@ -18,6 +18,7 @@ const useMutationAssignData = () => {
       Toast.success('등록 성공!!'); // 성공 시 모달 열기
       initialAssignData(); // 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: queryKeys.activities() }); // 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['currentPageActivity'] });
       navigate('/my/activity');
     },
     onError: (error) => {

--- a/src/hooks/useMutateModifyData.ts
+++ b/src/hooks/useMutateModifyData.ts
@@ -24,6 +24,7 @@ const useMutationModifyData = ({ schedules }: MutationModifyDataProps) => {
     onSuccess: () => {
       Toast.success('수정 성공!!'); // 성공 시 모달 열기
       queryClient.invalidateQueries({ queryKey: queryKeys.activities() }); // 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['currentPageActivity'] });
       initialModifyData();
       navigate('/my/activity');
     },


### PR DESCRIPTION
## 💻 작업 내용

- 등록/수정 페이지 시간대, 주소, 이미지 리팩토링 + 등록수정시 쿼리 무효화 + 패딩값 적용


## 🖼️ 스크린샷


## 🚨 관련 이슈 및 참고 사항

- 인풋을 클릭했을 때 모달창이 뜨도록 구현하였습니다. (사용자의 편의성 향상)
- 이미지 다중선택 기능은 이미지 추가 로직 상 맞지않아 보류하였습니다.
- MAX_SAFE_INTEGER에 대한 부분은 가격을 해당 숫자만큼 책정하지 않을 것 같아 일단 보류하였습니다.
