### PR TITLE
[GNTF-125] 체험 카드의 제목이 두 줄 이상 넘어갈 경우 말줄임표 처리

### DIFF
--- a/src/components/assignActivity/AssignTitle.tsx
+++ b/src/components/assignActivity/AssignTitle.tsx
@@ -14,7 +14,7 @@ const AssignTitle = () => {
         className="w-[100%] outline-none dark:bg-darkMode-black-20 dark:text-darkMode-white-10"
         onChange={handleChangeTitle}
         placeholder="제목"
-        maxLength={25}
+        maxLength={60}
       />
     </div>
   );

--- a/src/components/mainpage/ActivityCard.tsx
+++ b/src/components/mainpage/ActivityCard.tsx
@@ -56,7 +56,7 @@ const ActivityCard = ({
               <span className="text-gray-60 group-hover:text-green-80">{` (${reviewCount})`}</span>
             </p>
           </div>
-          <div className="text-2xl font-semibold pb-[5px] sm:text-lg sm:leading-tight">{title}</div>
+          <div className="text-2xl font-semibold mb-[5px] line-clamp-2 sm:text-lg sm:leading-tight">{title}</div>
           <div className="flex items-center gap-1 text-[28px] font-bold group-hover:text-green-20 sm:text-xl sm:leading-none">
             {priceToWon(price)}
             <span className="text-xl text-gray-80 font-normal group-hover:text-green-80 dark:text-darkMode-gray-10 sm:text-base">/인</span>

--- a/src/components/mainpage/PopularActivityCard.tsx
+++ b/src/components/mainpage/PopularActivityCard.tsx
@@ -49,7 +49,7 @@ const PopularActivityCard = ({
             <img src="/assets/bold_star.svg" alt="little-star" />
             <p className="text-sm font-bold">{`${rating} (${reviewCount})`}</p>
           </div>
-          <div className="text-3xl font-bold sm:text-lg">{title}</div>
+          <div className="text-3xl font-bold line-clamp-2 lg:text-2xl sm:text-lg sm:line-clamp-1">{title}</div>
           <div className="flex items-center gap-1 text-xl font-bold sm:text-base">
             {`₩ ${price}`}
             <span className="text-sm">/인</span>

--- a/src/components/modifyActivity/ModifyTitle.tsx
+++ b/src/components/modifyActivity/ModifyTitle.tsx
@@ -27,7 +27,7 @@ const ModifyTitle = ({ title }: ModifyTitleProps) => {
         value={localTitle}
         onChange={handleChangeTitle}
         placeholder="제목"
-        maxLength={25}
+        maxLength={60}
       />
     </div>
   );


### PR DESCRIPTION
## 💻 작업 내용

- 인기 / 모든 체험 카드에서 제목이 2줄 이상 넘어가는 경우 말줄임표 처리가 되도록 수정했습니다.
- 등록 / 수정 시에 제목 제한 25자에서 60자로 변경했습니다.


## 🖼️ 스크린샷
![스크린샷 2024-06-24 175524](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/1ae1aa01-b1a0-40ff-bb70-ac93f45b10b4)
![스크린샷 2024-06-24 175541](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/77ddee1c-dd71-4c4d-bf3e-347b6bd31457)
![스크린샷 2024-06-24 175825](https://github.com/Part4-Team15/GlobalNomad/assets/155137866/4c2f342c-5351-44f1-b548-be17ba28cf5f)


## 🚨 관련 이슈 및 참고 사항

- 없습니다.
